### PR TITLE
Fix typo in estadoCierreColors constant

### DIFF
--- a/src/constants/estadoCierreColors.js
+++ b/src/constants/estadoCierreColors.js
@@ -8,7 +8,7 @@ const estadoCierreColors = {
   en_revision:  { texto: "En Revisión", color: "bg-orange-400" },
   rechazado:    { texto: "Rechazado", color: "bg-red-600" },
   aprobado:     { texto: "Aprobado", color: "bg-green-500" },
-  completo:     { texto: "Compleado",color:"bg-green-700"},
+  completo:     { texto: "Completado",color:"bg-green-700"},
 };
 
 export default estadoCierreColors;


### PR DESCRIPTION
## Summary
- correct 'Compleado' typo to 'Completado' in estadoCierreColors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f4c4fc6348323b82f88caf2495f48