### PR TITLE
Remove immediate concept deletion

### DIFF
--- a/src/components/ModalClasificacionHeaders.jsx
+++ b/src/components/ModalClasificacionHeaders.jsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import CreatableSelect from "react-select/creatable";
 import {
   obtenerClasificacionesCliente,
-  eliminarConceptoRemuneracion,
 } from "../api/nomina";
 
 const categorias = ["haber", "descuento", "informacion"];
@@ -105,16 +104,6 @@ const ModalClasificacionHeaders = ({
     if (seleccionado === header) setSeleccionado(null);
   };
 
-  const eliminarConcepto = async (header) => {
-    if (!clienteId) return;
-    if (!window.confirm(`¿Eliminar concepto "${header}"?`)) return;
-    try {
-      await eliminarConceptoRemuneracion(clienteId, header);
-      eliminarClasificacion(header);
-    } catch (e) {
-      console.error("Error eliminando concepto:", e);
-    }
-  };
 
   const handleGuardar = () => {
     const resultado = {};
@@ -177,16 +166,6 @@ const ModalClasificacionHeaders = ({
                             title="Quitar clasificación"
                           >
                             ✖
-                          </button>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              eliminarConcepto(header);
-                            }}
-                            className="text-red-400 text-xs"
-                            title="Eliminar concepto"
-                          >
-                            🗑
                           </button>
                         </div>
                       )}


### PR DESCRIPTION
## Summary
- simplify header classification modal by removing the trash can button
- keep a single ✖ icon to move headers back to *Pendientes*

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f90b6c0188323abcfcafde3eb86a2