### PR TITLE
Defer header updates until save

### DIFF
--- a/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
+++ b/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
@@ -5,7 +5,7 @@ import {
   obtenerEstadoLibroRemuneraciones,
   subirLibroRemuneraciones,
   guardarConceptosRemuneracion,
-  obtenerClasificacionesCliente,
+  eliminarConceptoRemuneracion,
 } from "../../api/nomina";
 
 const CierreProgresoNomina = ({ cierre, cliente }) => {
@@ -13,9 +13,16 @@ const CierreProgresoNomina = ({ cierre, cliente }) => {
   const [subiendo, setSubiendo] = useState(false);
   const [modalAbierto, setModalAbierto] = useState(false);
 
-  const handleGuardarClasificaciones = async (clasificaciones) => {
+  const handleGuardarClasificaciones = async ({ guardar, eliminar }) => {
     try {
-      await guardarConceptosRemuneracion(cliente.id, clasificaciones);
+      if (guardar && Object.keys(guardar).length > 0) {
+        await guardarConceptosRemuneracion(cliente.id, guardar);
+      }
+      if (Array.isArray(eliminar) && eliminar.length > 0) {
+        await Promise.all(
+          eliminar.map((h) => eliminarConceptoRemuneracion(cliente.id, h))
+        );
+      }
       await obtenerEstadoLibroRemuneraciones(cierre.id).then(setLibro);
     } catch (error) {
       console.error("Error al guardar clasificaciones:", error);


### PR DESCRIPTION
## Summary
- track original header classifications
- send updates and deletions together in `handleGuardar`
- apply batch operations when saving in `CierreProgresoNomina`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f90b6c0188323abcfcafde3eb86a2