### PR TITLE
Fix hashtag suggestion updates

### DIFF
--- a/backend/nomina/urls.py
+++ b/backend/nomina/urls.py
@@ -10,6 +10,7 @@ from .views import (
     obtener_hashtags_disponibles,
     ConceptoRemuneracionBatchView,
     eliminar_concepto_remuneracion,
+    progreso_clasificacion_libro_remuneraciones,
 )
 from django.urls import path
 from django.conf import settings
@@ -50,6 +51,11 @@ urlpatterns = router.urls + [
         "conceptos/<int:cliente_id>/<path:nombre_concepto>/eliminar/",
         eliminar_concepto_remuneracion,
         name="eliminar-concepto-remuneracion",
+    ),
+    path(
+        "libro_remuneraciones/progreso_clasificacion/<int:cierre_id>/",
+        progreso_clasificacion_libro_remuneraciones,
+        name="progreso-clasificacion-libro-remuneraciones",
     ),
 
 ]

--- a/src/components/ModalClasificacionHeaders.jsx
+++ b/src/components/ModalClasificacionHeaders.jsx
@@ -244,6 +244,10 @@ const ModalClasificacionHeaders = ({
                     ...prev,
                     [seleccionado]: etiquetas.join(", ")
                   }));
+                  setHashtagsDisponibles((prev) => {
+                    const nuevos = etiquetas.filter((tag) => !prev.includes(tag));
+                    return [...prev, ...nuevos].sort();
+                  });
                 }}
                 options={hashtagsDisponibles.map(tag => ({ label: tag, value: tag }))}
                 placeholder="Ej: Bono, Legal, Fijo"

--- a/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
+++ b/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
@@ -6,12 +6,14 @@ import {
   subirLibroRemuneraciones,
   guardarConceptosRemuneracion,
   eliminarConceptoRemuneracion,
+  obtenerProgresoClasificacionRemu,
 } from "../../api/nomina";
 
 const CierreProgresoNomina = ({ cierre, cliente }) => {
   const [libro, setLibro] = useState(null);
   const [subiendo, setSubiendo] = useState(false);
   const [modalAbierto, setModalAbierto] = useState(false);
+  const [libroListo, setLibroListo] = useState(false);
 
   const handleGuardarClasificaciones = async ({ guardar, eliminar }) => {
     try {
@@ -23,7 +25,15 @@ const CierreProgresoNomina = ({ cierre, cliente }) => {
           eliminar.map((h) => eliminarConceptoRemuneracion(cliente.id, h))
         );
       }
-      await obtenerEstadoLibroRemuneraciones(cierre.id).then(setLibro);
+      // Refrescamos los conteos consultando nuevamente el backend
+      const [nuevoEstado, progreso] = await Promise.all([
+        obtenerEstadoLibroRemuneraciones(cierre.id),
+        obtenerProgresoClasificacionRemu(cierre.id),
+      ]);
+      setLibro({
+        ...nuevoEstado,
+        header_json: progreso,
+      });
     } catch (error) {
       console.error("Error al guardar clasificaciones:", error);
     }
@@ -39,16 +49,39 @@ const CierreProgresoNomina = ({ cierre, cliente }) => {
 
   useEffect(() => {
     if (cierre?.id) {
-      obtenerEstadoLibroRemuneraciones(cierre.id).then(setLibro);
+      Promise.all([
+        obtenerEstadoLibroRemuneraciones(cierre.id),
+        obtenerProgresoClasificacionRemu(cierre.id),
+      ]).then(([estado, progreso]) => {
+        setLibro({ ...estado, header_json: progreso });
+      });
     }
   }, [cierre]);
+
+  // Detecta cuando no quedan headers por clasificar
+  useEffect(() => {
+    const sinClasificar = Array.isArray(libro?.header_json?.headers_sin_clasificar)
+      ? libro.header_json.headers_sin_clasificar.length === 0
+      : false;
+    if (sinClasificar && !libroListo) {
+      setLibroListo(true);
+      console.log("Libro de remuneraciones listo");
+    } else if (!sinClasificar && libroListo) {
+      setLibroListo(false);
+    }
+  }, [libro, libroListo]);
 
   const handleSubirArchivo = async (archivo) => {
     setSubiendo(true);
     try {
       await subirLibroRemuneraciones(cierre.id, archivo);
       setTimeout(() => {
-        obtenerEstadoLibroRemuneraciones(cierre.id).then(setLibro);
+        Promise.all([
+          obtenerEstadoLibroRemuneraciones(cierre.id),
+          obtenerProgresoClasificacionRemu(cierre.id),
+        ]).then(([estado, progreso]) => {
+          setLibro({ ...estado, header_json: progreso });
+        });
       }, 1200);
     } finally {
       setSubiendo(false);
@@ -73,7 +106,9 @@ const CierreProgresoNomina = ({ cierre, cliente }) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       <LibroRemuneracionesCard
-        estado={libro?.estado || "no_subido"}
+        estado={
+          libroListo ? "clasificado" : libro?.estado || "no_subido"
+        }
         archivoNombre={libro?.archivo_nombre}
         subiendo={subiendo}
         onSubirArchivo={handleSubirArchivo}


### PR DESCRIPTION
## Summary
- refresh classification progress from backend on save or upload
- compute remaining headers server-side via new endpoint

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_683fd002adc08323af111ccd9eba62a1