### PR TITLE
Fix payroll card classification counts

### DIFF
--- a/src/api/nomina.js
+++ b/src/api/nomina.js
@@ -112,11 +112,19 @@ export const obtenerClasificacionesCliente = async (clienteId) => {
 };
 //--------------------------
 
-export const guardarConceptosRemuneracion = async (clienteId, conceptos) => {
-  const response = await api.post(`/nomina/conceptos/`, {
+export const guardarConceptosRemuneracion = async (
+  clienteId,
+  conceptos,
+  cierreId = null
+) => {
+  const payload = {
     cliente_id: clienteId,
-    conceptos: conceptos,
-  });
+    conceptos,
+  };
+  if (cierreId) {
+    payload.cierre_id = cierreId;
+  }
+  const response = await api.post(`/nomina/conceptos/`, payload);
   return response.data;
 };
 

--- a/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
+++ b/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
@@ -16,9 +16,9 @@ const CierreProgresoNomina = ({ cierre, cliente }) => {
 
   const handleGuardarClasificaciones = async ({ guardar, eliminar }) => {
     try {
-      if (guardar && Object.keys(guardar).length > 0) {
-        await guardarConceptosRemuneracion(cliente.id, guardar);
-      }
+        if (guardar && Object.keys(guardar).length > 0) {
+          await guardarConceptosRemuneracion(cliente.id, guardar, cierre.id);
+        }
       if (Array.isArray(eliminar) && eliminar.length > 0) {
         await Promise.all(
           eliminar.map((h) => eliminarConceptoRemuneracion(cliente.id, h))


### PR DESCRIPTION
## Summary
- update classification endpoint to refresh libro headers after saving
- accept optional cierre_id in guardarConceptosRemuneracion
- update React component to send cierre_id when saving classifications

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683fd8bbc9108323868613cc89162bed