### PR TITLE
Fix header modal to always list headers

### DIFF
--- a/src/components/ModalClasificacionHeaders.jsx
+++ b/src/components/ModalClasificacionHeaders.jsx
@@ -66,13 +66,18 @@ const ModalClasificacionHeaders = ({
           informacion: [],
         };
 
-        headersSinClasificar.forEach((h) => {
+        const todosHeaders = new Set([
+          ...headersSinClasificar,
+          ...Object.keys(clasificados),
+        ]);
+
+        todosHeaders.forEach((h) => {
           const info = clasificados[h];
-          if (info && nuevoHeaders[info.clasificacion]) {
-            nuevoHeaders[info.clasificacion].push(h);
-          } else {
-            nuevoHeaders.pendiente.push(h);
-          }
+          const destino =
+            info && nuevoHeaders[info.clasificacion]
+              ? info.clasificacion
+              : "pendiente";
+          nuevoHeaders[destino].push(h);
         });
 
         setHeaders(nuevoHeaders);


### PR DESCRIPTION
## Summary
- ensure ModalClasificacionHeaders also loads already classified headers

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840747326e483238c8d3664c49385aa