### PR TITLE
Adjust classification save procedure

### DIFF
--- a/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
+++ b/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
@@ -21,14 +21,23 @@ const CierreProgresoNomina = ({ cierre, cliente }) => {
 
   const handleGuardarClasificaciones = async ({ guardar, eliminar }) => {
     try {
-        if (guardar && Object.keys(guardar).length > 0) {
-          await guardarConceptosRemuneracion(cliente.id, guardar, cierre.id);
-        }
+      // Primero eliminamos las clasificaciones que correspondan
       if (Array.isArray(eliminar) && eliminar.length > 0) {
         await Promise.all(
           eliminar.map((h) => eliminarConceptoRemuneracion(cliente.id, h))
         );
       }
+
+      const tieneGuardar = guardar && Object.keys(guardar).length > 0;
+
+      // Luego guardamos las nuevas clasificaciones
+      if (tieneGuardar) {
+        await guardarConceptosRemuneracion(cliente.id, guardar, cierre.id);
+      } else if (Array.isArray(eliminar) && eliminar.length > 0) {
+        // Si sólo se eliminaron conceptos, indicamos al backend que recalcule
+        await guardarConceptosRemuneracion(cliente.id, {}, cierre.id);
+      }
+
       // Refrescamos los conteos consultando nuevamente el backend
       const nuevoEstado = await obtenerEstadoLibroRemuneraciones(cierre.id);
       setLibro(nuevoEstado);


### PR DESCRIPTION
## Summary
- reorder calls in `handleGuardarClasificaciones` so deletions happen before saves
- call `guardarConceptosRemuneracion` with an empty object when only deletions occur
- always refresh state from `obtenerEstadoLibroRemuneraciones`

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68407e20a14c8323a8b823ddfc9368b8