### PR TITLE
Add employee model and parsing from remuneration book

### DIFF
--- a/backend/nomina/migrations/0010_empleado.py
+++ b/backend/nomina/migrations/0010_empleado.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nomina', '0009_alter_libroremuneracionesupload_estado'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Empleado',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('rut', models.CharField(max_length=12, unique=True)),
+                ('nombres', models.CharField(max_length=120)),
+                ('apellido_paterno', models.CharField(max_length=120)),
+                ('apellido_materno', models.CharField(blank=True, max_length=120)),
+                ('activo', models.BooleanField(default=True)),
+                ('fecha_ingreso', models.DateField(blank=True, null=True)),
+            ],
+        ),
+    ]

--- a/backend/nomina/models.py
+++ b/backend/nomina/models.py
@@ -29,6 +29,18 @@ def analista_upload_to(instance, filename):
     return f"remuneraciones/{cliente_id}/{periodo}/{tipo_archivo}/{now}_{filename}"
 
 
+class Empleado(models.Model):
+    rut = models.CharField(max_length=12, unique=True)
+    nombres = models.CharField(max_length=120)
+    apellido_paterno = models.CharField(max_length=120)
+    apellido_materno = models.CharField(max_length=120, blank=True)
+    activo = models.BooleanField(default=True)
+    fecha_ingreso = models.DateField(null=True, blank=True)
+
+    def __str__(self):
+        return f"{self.rut} - {self.nombres} {self.apellido_paterno}"
+
+
 
 
 class CierreNomina(models.Model):
@@ -132,6 +144,7 @@ class MovimientosMesUpload(models.Model):
 
 class MovimientoAltaBaja(models.Model):
     movimientos_mes = models.ForeignKey(MovimientosMesUpload, on_delete=models.CASCADE)
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     nombre = models.CharField(max_length=120)
     tipo_movimiento = models.CharField(max_length=20, choices=[('alta', 'Alta'), ('baja', 'Baja')])
@@ -143,6 +156,7 @@ class MovimientoAltaBaja(models.Model):
 
 class MovimientoAusentismo(models.Model):
     movimientos_mes = models.ForeignKey(MovimientosMesUpload, on_delete=models.CASCADE)
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     nombre = models.CharField(max_length=120)
     tipo_ausentismo = models.CharField(max_length=80)  # Licencia, Permiso, etc.
@@ -156,6 +170,7 @@ class MovimientoAusentismo(models.Model):
 
 class MovimientoVacaciones(models.Model):
     movimientos_mes = models.ForeignKey(MovimientosMesUpload, on_delete=models.CASCADE)
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     nombre = models.CharField(max_length=120)
     fecha_inicio = models.DateField()
@@ -168,6 +183,7 @@ class MovimientoVacaciones(models.Model):
 
 class VariacionSueldoBase(models.Model):
     movimientos_mes = models.ForeignKey(MovimientosMesUpload, on_delete=models.CASCADE)
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     nombre = models.CharField(max_length=120)
     sueldo_anterior = models.DecimalField(max_digits=12, decimal_places=2)
@@ -180,6 +196,7 @@ class VariacionSueldoBase(models.Model):
 
 class VariacionTipoContrato(models.Model):
     movimientos_mes = models.ForeignKey(MovimientosMesUpload, on_delete=models.CASCADE)
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     nombre = models.CharField(max_length=120)
     tipo_anterior = models.CharField(max_length=80)
@@ -219,6 +236,7 @@ class ArchivoAnalistaUpload(models.Model):
 
 class RegistroIngresoAnalista(models.Model):
     archivo_upload = models.ForeignKey(ArchivoAnalistaUpload, on_delete=models.CASCADE)
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     nombre = models.CharField(max_length=120)
     fecha_ingreso = models.DateField()
@@ -230,6 +248,7 @@ class RegistroIngresoAnalista(models.Model):
 
 class RegistroFiniquitoAnalista(models.Model):
     archivo_upload = models.ForeignKey(ArchivoAnalistaUpload, on_delete=models.CASCADE)
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     nombre = models.CharField(max_length=120)
     fecha_finiquito = models.DateField()
@@ -241,6 +260,7 @@ class RegistroFiniquitoAnalista(models.Model):
 
 class RegistroAusentismoAnalista(models.Model):
     archivo_upload = models.ForeignKey(ArchivoAnalistaUpload, on_delete=models.CASCADE)
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     nombre = models.CharField(max_length=120)
     tipo_ausentismo = models.CharField(max_length=80)
@@ -255,6 +275,7 @@ class RegistroAusentismoAnalista(models.Model):
 class IncidenciaComparacion(models.Model):
     cierre = models.ForeignKey(CierreNomina, on_delete=models.CASCADE, related_name='incidencias_comparacion')
     tipo_incidencia = models.CharField(max_length=30)
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     detalle = models.TextField()
     resuelto = models.BooleanField(default=False)
@@ -295,6 +316,7 @@ class ArchivoNovedadesUpload(models.Model):
 
 class Novedad(models.Model):
     archivo_upload = models.ForeignKey(ArchivoNovedadesUpload, on_delete=models.CASCADE, null=True, blank=True, related_name='novedades')
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     nombre = models.CharField(max_length=120, blank=True, null=True)
     concepto = models.CharField(max_length=120)  # Header del archivo novedad
@@ -313,6 +335,7 @@ class Novedad(models.Model):
 
 class IncidenciaNovedad(models.Model):
     cierre = models.ForeignKey(CierreNomina, on_delete=models.CASCADE, related_name='incidencias_novedad')
+    empleado = models.ForeignKey('Empleado', on_delete=models.CASCADE, null=True, blank=True)
     rut = models.CharField(max_length=12)
     nombre = models.CharField(max_length=120, blank=True, null=True)
     concepto = models.CharField(max_length=120)

--- a/backend/nomina/serializers.py
+++ b/backend/nomina/serializers.py
@@ -3,8 +3,14 @@ from .models import (
     CierreNomina, LibroRemuneracionesUpload, MovimientosMesUpload,
     ArchivoAnalistaUpload, ArchivoNovedadesUpload,
     ConceptoRemuneracion, Novedad,
-    IncidenciaComparacion, IncidenciaNovedad, ChecklistItem
+    IncidenciaComparacion, IncidenciaNovedad, ChecklistItem, Empleado
 )
+
+
+class EmpleadoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Empleado
+        fields = ['id', 'rut', 'nombres', 'apellido_paterno', 'apellido_materno', 'activo', 'fecha_ingreso']
 
 class ChecklistItemSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/nomina/tasks.py
+++ b/backend/nomina/tasks.py
@@ -1,7 +1,7 @@
 #nomina/tasks.py
 from .utils.LibroRemuneraciones import obtener_headers_libro_remuneraciones, clasificar_headers_libro_remuneraciones
 from celery import shared_task
-from .models import LibroRemuneracionesUpload
+from .models import LibroRemuneracionesUpload, Empleado
 import logging
 import pandas as pd
 
@@ -62,6 +62,7 @@ def clasificar_headers_libro_remuneraciones_task(result):
             f"{len(headers_sin_clasificar)} sin clasificar"
         )
         return {
+            "libro_id": libro_id,
             "headers_clasificados": len(headers_clasificados),
             "headers_sin_clasificar": len(headers_sin_clasificar)
         }
@@ -74,4 +75,42 @@ def clasificar_headers_libro_remuneraciones_task(result):
             libro.save()
         except Exception as ex:
             logger.error(f"Error guardando estado 'con_error' para libro id={libro_id}: {ex}")
+        raise
+
+
+@shared_task
+def actualizar_empleados_desde_libro(result):
+    libro_id = result.get('libro_id') if isinstance(result, dict) else result
+    try:
+        libro = LibroRemuneracionesUpload.objects.get(id=libro_id)
+        df = pd.read_excel(libro.archivo.path)
+
+        rut_col = next((c for c in df.columns if 'rut' in c.lower() and 'trab' in c.lower()), None)
+        dv_col = next((c for c in df.columns if 'dv' in c.lower() and 'trab' in c.lower()), None)
+        ape_pat_col = next((c for c in df.columns if 'apellido' in c.lower() and 'pater' in c.lower()), None)
+        ape_mat_col = next((c for c in df.columns if 'apellido' in c.lower() and 'mater' in c.lower()), None)
+        nombres_col = next((c for c in df.columns if 'nombre' in c.lower()), None)
+        ingreso_col = next((c for c in df.columns if 'ingreso' in c.lower()), None)
+
+        count = 0
+        for _, row in df.iterrows():
+            rut_num = str(row.get(rut_col, '')).strip()
+            dv = str(row.get(dv_col, '')).strip()
+            rut = f"{rut_num}-{dv}" if dv else rut_num
+            defaults = {
+                'nombres': str(row.get(nombres_col, '')).strip(),
+                'apellido_paterno': str(row.get(ape_pat_col, '')).strip(),
+                'apellido_materno': str(row.get(ape_mat_col, '')).strip(),
+            }
+            if ingreso_col:
+                try:
+                    defaults['fecha_ingreso'] = pd.to_datetime(row[ingreso_col]).date()
+                except Exception:
+                    pass
+            Empleado.objects.update_or_create(rut=rut, defaults=defaults)
+            count += 1
+        logger.info(f"Actualizados {count} empleados desde libro {libro_id}")
+        return {'libro_id': libro_id, 'empleados_actualizados': count}
+    except Exception as e:
+        logger.error(f"Error actualizando empleados para libro id={libro_id}: {e}")
         raise

--- a/backend/nomina/urls.py
+++ b/backend/nomina/urls.py
@@ -6,6 +6,7 @@ from .views import (
     ArchivoAnalistaUploadViewSet,
     ArchivoNovedadesUploadViewSet,
     ChecklistItemViewSet,
+    EmpleadoViewSet,
     conceptos_remuneracion_por_cliente,
     obtener_hashtags_disponibles,
     ConceptoRemuneracionBatchView,
@@ -23,6 +24,7 @@ router.register(r'movimientos-mes', MovimientosMesUploadViewSet)
 router.register(r'archivos-analista', ArchivoAnalistaUploadViewSet)
 router.register(r'archivos-novedades', ArchivoNovedadesUploadViewSet)
 router.register(r'checklist-items', ChecklistItemViewSet)
+router.register(r'empleados', EmpleadoViewSet)
 
 urlpatterns = router.urls + [
     path(


### PR DESCRIPTION
## Summary
- add an `Empleado` model
- link movement and novelty models to `Empleado`
- parse uploaded remuneration books to sync employees
- expose employees by API and hook into upload pipeline
- create initial migration for new table

## Testing
- `python manage.py makemigrations` *(fails: Could not find Django)*

------
https://chatgpt.com/codex/tasks/task_e_68408482b47c8323aeaba0c476d81120