### PR TITLE
Clean up debug logs

### DIFF
--- a/backend/contabilidad/tasks.py
+++ b/backend/contabilidad/tasks.py
@@ -8,13 +8,16 @@ from django.utils import timezone
 from django.core.files.storage import default_storage
 import time
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @shared_task
 def tarea_de_prueba(nombre):
-    print(f"👋 ¡Hola {nombre} desde Celery!") #print1
+    logger.info("👋 ¡Hola %s desde Celery!", nombre)
     time.sleep(999)
-    print("✅ Tarea completada.") #print2
+    logger.info("✅ Tarea completada.")
     return f"Completado por {nombre}" #esto sale en succeeded
 
 
@@ -22,9 +25,9 @@ def tarea_de_prueba(nombre):
 def parsear_tipo_documento(cliente_id, ruta_relativa):
     ok, msg = parsear_tipo_documento_excel(cliente_id, ruta_relativa)
     if ok:
-        print("✅", msg)
+        logger.info("✅ %s", msg)
     else:
-        print("❌", msg)
+        logger.error("❌ %s", msg)
     return msg
 
 @shared_task

--- a/backend/contabilidad/utils/parser_nombre_ingles.py
+++ b/backend/contabilidad/utils/parser_nombre_ingles.py
@@ -1,17 +1,20 @@
 import openpyxl
 from contabilidad.models import CuentaContable
 from django.core.files.storage import default_storage
+import logging
+
+logger = logging.getLogger(__name__)
 
 def procesar_archivo_nombres_ingles(cliente_id, path_archivo):
     path = default_storage.path(path_archivo)
-    print(f"Procesando archivo de nombres en inglés: {path}")
+    logger.info("Procesando archivo de nombres en inglés: %s", path)
     wb = openpyxl.load_workbook(filename=path)
     ws = wb.active
     actualizados = 0
     for idx, row in enumerate(ws.iter_rows(min_row=2), start=2):
         codigo = str(row[0].value).strip() if row[0].value else ""
         nombre_en = str(row[1].value).strip() if len(row) > 1 and row[1].value else ""
-        print(f"[Fila {idx}] codigo: '{codigo}' | nombre_en: '{nombre_en}'")
+        logger.debug("[Fila %s] codigo: '%s' | nombre_en: '%s'", idx, codigo, nombre_en)
         if codigo and nombre_en:
             try:
                 cuenta = CuentaContable.objects.get(cliente_id=cliente_id, codigo=codigo)
@@ -19,10 +22,10 @@ def procesar_archivo_nombres_ingles(cliente_id, path_archivo):
                 cuenta.save(update_fields=["nombre_en"])
                 actualizados += 1
             except CuentaContable.DoesNotExist:
-                print(f"[Fila {idx}] No existe cuenta con código: '{codigo}' para cliente: {cliente_id}")
+                logger.warning("[Fila %s] No existe cuenta con código: '%s' para cliente: %s", idx, codigo, cliente_id)
                 continue
         else:
-            print(f"[Fila {idx}] Código vacío o nombre_en vacío: '{codigo}', '{nombre_en}'")
+            logger.warning("[Fila %s] Código vacío o nombre_en vacío: '%s', '%s'", idx, codigo, nombre_en)
     default_storage.delete(path_archivo)
-    print (f"✅ Procesados {actualizados} nombres en inglés para cliente {cliente_id}")
+    logger.info("✅ Procesados %s nombres en inglés para cliente %s", actualizados, cliente_id)
     return actualizados

--- a/backend/contabilidad/utils/parser_tipo_documento.py
+++ b/backend/contabilidad/utils/parser_tipo_documento.py
@@ -1,6 +1,9 @@
 from contabilidad.models import Cliente, TipoDocumento
 from django.core.files.storage import default_storage
 import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
 
 def parsear_tipo_documento_excel(cliente_id, ruta_relativa):
     path = default_storage.path(ruta_relativa)
@@ -10,7 +13,7 @@ def parsear_tipo_documento_excel(cliente_id, ruta_relativa):
         df.columns = df.columns.str.lower()
         df = df.dropna(subset=["codigo"])
     except Exception as e:
-        print(f"[ERROR XLSX] {e}")
+        logger.error("[ERROR XLSX] %s", e)
         default_storage.delete(ruta_relativa)
         return False, f"Error leyendo archivo: {e}"
 
@@ -33,5 +36,5 @@ def parsear_tipo_documento_excel(cliente_id, ruta_relativa):
     # Borrar archivo
     default_storage.delete(ruta_relativa)
 
-    print(f"✅ Procesados {len(objetos)} tipos para cliente {cliente.nombre}")
+    logger.info("✅ Procesados %s tipos para cliente %s", len(objetos), cliente.nombre)
     return True, f"{len(objetos)} tipos creados"

--- a/backend/contabilidad/views.py
+++ b/backend/contabilidad/views.py
@@ -1,6 +1,6 @@
 #backend/contabilidad/views.py
 from rest_framework import viewsets
-from rest_framework.decorators import api_view, permission_classes, parser_classes, action  
+from rest_framework.decorators import api_view, permission_classes, parser_classes, action
 from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -13,6 +13,9 @@ from datetime import date
 import os
 from django.db.models import Q
 from contabilidad.permissions import PuedeCrearCierreContabilidad, SoloContabilidadAsignadoOGerente
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 from .models import (
@@ -77,8 +80,7 @@ def verificar_y_marcar_completo(cuenta_id):
             cierre.estado = "completo"
             cierre.save(update_fields=["estado"])
     except Exception as e:
-        # Opcional: loggear el error
-        print(f"Error al verificar cierre completo: {e}")
+        logger.exception("Error al verificar cierre completo: %s", e)
 
 class ClasificacionViewSet(viewsets.ViewSet):
     permission_classes = [IsAuthenticated]

--- a/backend/nomina/serializers.py
+++ b/backend/nomina/serializers.py
@@ -5,6 +5,9 @@ from .models import (
     ConceptoRemuneracion, Novedad,
     IncidenciaComparacion, IncidenciaNovedad, ChecklistItem
 )
+import logging
+
+logger = logging.getLogger(__name__)
 
 class ChecklistItemSerializer(serializers.ModelSerializer):
     class Meta:
@@ -37,9 +40,12 @@ class CierreNominaCreateSerializer(serializers.ModelSerializer):
     def validate(self, data):
         cliente = data.get('cliente')
         periodo = data.get('periodo')
-        print("VALIDANDO: cliente:", cliente, "periodo:", periodo)
+        logger.debug("VALIDANDO cierre nomina", extra={
+            "cliente": cliente.id if hasattr(cliente, "id") else cliente,
+            "periodo": periodo,
+        })
         existe = CierreNomina.objects.filter(cliente=cliente, periodo=periodo).exists()
-        print("¿Existe cierre?", existe)
+        logger.debug("¿Existe cierre? %s", existe)
         if existe:
             raise serializers.ValidationError("Ya existe un cierre para este cliente en ese periodo.")
         return data

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -6,7 +6,6 @@ export const loginUsuario = async (correo, password) => {
     correo_bdo: correo,
     password,
   });
-  console.log("Login response:", response.data);
   return response.data;
 };
 

--- a/src/api/contabilidad.js
+++ b/src/api/contabilidad.js
@@ -189,7 +189,6 @@ export const obtenerCierresCliente = async (clienteId) => {
     params: { cliente: clienteId }
     
   });
-  console.log("Cierres obtenidos:", res.data);
   return res.data; // [{ id, periodo, estado, ... }]
 };
 

--- a/src/api/nomina.js
+++ b/src/api/nomina.js
@@ -62,7 +62,6 @@ export const subirLibroRemuneraciones = async (cierreId, archivo) => {
 };
 export const obtenerEstadoLibroRemuneraciones = async (cierreId) => {
   const res = await api.get(`/nomina/libros-remuneraciones/estado/${cierreId}/`);
-  console.log("Estado Libro Remuneraciones:", res.data);
   return res.data;
 };
 export const obtenerConceptosLibroRemuneraciones = async (clienteId, periodo) => {

--- a/src/components/ClienteRow.jsx
+++ b/src/components/ClienteRow.jsx
@@ -21,7 +21,6 @@ const ClienteRow = ({ cliente, areaActiva }) => {
     ultimo_cierre: null,
     estado_cierre_actual: null,
   });
-  console.log("ClienteRow renderizado para:", cliente.nombre, "Área activa:", areaActiva);
   useEffect(() => {
     const fetchResumen = async () => {
       try {

--- a/src/components/CrearCierre/CrearCierreCard.jsx
+++ b/src/components/CrearCierre/CrearCierreCard.jsx
@@ -71,7 +71,6 @@ const CrearCierreCard = ({ clienteId, areaActiva }) => {
         setLoading(false);
         return;
       }
-      console.log("Cierre existente:", cierreExistente);
       
 
 
@@ -89,7 +88,6 @@ const CrearCierreCard = ({ clienteId, areaActiva }) => {
         navigate(`/menu/nomina/cierres/${cierre.id}`);
       }
     } catch (err) {
-        console.log("Error detalle:", err.response?.data); // <- agrega esto
         setError("Error creando el cierre.");
       }
 

--- a/src/components/TarjetasCierreContabilidad/NombresEnInglesCard.jsx
+++ b/src/components/TarjetasCierreContabilidad/NombresEnInglesCard.jsx
@@ -19,7 +19,6 @@ const NombresEnInglesCard = ({
 
       const fetchEstado = async () => {
          
-        console.log("[NombresEnInglesCard] useEffect ejecutado", { cierreId, clienteId, clasificacionReady });
         if (!cierreId || !clienteId || !clasificacionReady) {
           setEstado("pendiente");
           setFaltantes(0);
@@ -34,9 +33,6 @@ const NombresEnInglesCard = ({
           const total = data.total || 0;
           const faltantes = data.faltantes ? data.faltantes.length : 0;
           const traducidas = total - faltantes;
-          console.log(
-            `[NombresEnInglesCard] Cuentas analizadas: ${total}, Sin traducción: ${faltantes}, Con traducción: ${traducidas}`
-          );
 
           // Si no hay cuentas (total === 0) o faltantes === 0, se considera completado.
           const esCompletado = (faltantes === 0 && total > 0) || data.estado === "subido";

--- a/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
+++ b/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
@@ -68,7 +68,6 @@ const CierreProgresoNomina = ({ cierre, cliente }) => {
       : false;
     if (sinClasificar && !libroListo) {
       setLibroListo(true);
-      console.log("Libro de remuneraciones listo");
     } else if (!sinClasificar && libroListo) {
       setLibroListo(false);
     }

--- a/src/pages/ClienteDetalle.jsx
+++ b/src/pages/ClienteDetalle.jsx
@@ -51,8 +51,6 @@ const ClienteDetalle = () => {
   if (!cliente || !resumen) {
     return <p className="text-white">Cargando cliente...</p>;
   }
-  console.log("Cliente:", cliente);
-  console.log("Resumen:", resumen);
 
   return (
     <div className="text-white space-y-6">

--- a/src/pages/Clientes.jsx
+++ b/src/pages/Clientes.jsx
@@ -17,7 +17,6 @@ const Clientes = () => {
       setError("");
       try {
         const userData = await obtenerUsuario();
-        console.log("Usuario obtenido:", userData);
 
         setUsuario(userData);
         

--- a/src/pages/PaginaClasificacion.jsx
+++ b/src/pages/PaginaClasificacion.jsx
@@ -61,9 +61,7 @@ const PaginaClasificacion = () => {
   async function fetchOptions(setId) {
     setLoading(true);
     try {
-      console.log("Buscando opciones para setId:", setId);
       const data = await obtenerOpcionesClasificacion(setId);
-      console.log("Opciones obtenidas:", data);
       setOptions(data);
     } catch {
       setMensaje("Error cargando opciones.");


### PR DESCRIPTION
## Summary
- swap print statements for logger usage in backend serializers and utilities
- remove stray console.log calls from React components and API helpers

## Testing
- `pytest`
- `npm run lint` *(fails: 1666 problems)*

------
https://chatgpt.com/codex/tasks/task_e_684084b51b0c8323b6d4af0423009a5e