### PR TITLE
Add hierarchical classification to accounting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Python artifacts
+**/__pycache__/
+backend/venv/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/backend/contabilidad/migrations/0011_clasificacion_hierarchy.py
+++ b/backend/contabilidad/migrations/0011_clasificacion_hierarchy.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contabilidad', '0010_rename_cierremensual_cierrecontabilidad'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='clasificacionset',
+            name='idioma',
+            field=models.CharField(choices=[('es', 'Español'), ('en', 'English')], default='es', max_length=2),
+        ),
+        migrations.AddField(
+            model_name='clasificacionoption',
+            name='parent',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='sub_opciones', to='contabilidad.clasificacionoption'),
+        ),
+    ]

--- a/backend/contabilidad/models.py
+++ b/backend/contabilidad/models.py
@@ -196,6 +196,11 @@ class ClasificacionSet(models.Model):
     cliente = models.ForeignKey(Cliente, on_delete=models.CASCADE)
     nombre = models.CharField(max_length=100)
     descripcion = models.TextField(blank=True)
+    idioma = models.CharField(
+        max_length=2,
+        choices=[("es", "Español"), ("en", "English")],
+        default="es",
+    )
 
     class Meta:
         unique_together = ('cliente', 'nombre')
@@ -205,9 +210,29 @@ class ClasificacionSet(models.Model):
 
 class ClasificacionOption(models.Model):
     id = models.BigAutoField(primary_key=True)
-    set_clas = models.ForeignKey(ClasificacionSet, on_delete=models.CASCADE, related_name='opciones')
+    set_clas = models.ForeignKey(
+        ClasificacionSet,
+        on_delete=models.CASCADE,
+        related_name='opciones'
+    )
+    parent = models.ForeignKey(
+        'self',
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name='sub_opciones'
+    )
     valor = models.CharField(max_length=100)
     descripcion = models.TextField(blank=True)
+
+    @property
+    def nivel(self):
+        n = 1
+        p = self.parent
+        while p:
+            n += 1
+            p = p.parent
+        return n
 
    
     def __str__(self):


### PR DESCRIPTION
## Summary
- enable language and parent options for accounting classifications
- add migration for new fields
- ignore Python artifacts

## Testing
- `PYTHONDONTWRITEBYTECODE=1 backend/venv/bin/python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django_redis')*

------
https://chatgpt.com/codex/tasks/task_e_6840bfb3a69c832397eb3909178796fd