### PR TITLE
Fix RegistroNomina string representation

### DIFF
--- a/backend/nomina/models.py
+++ b/backend/nomina/models.py
@@ -393,7 +393,7 @@ class RegistroNomina(models.Model):
     )
 
     def __str__(self):
-        return f"{self.empleado.rut} - {self.cierre.periodo}"
+        return f"{self.empleado.rut_trabajador} - {self.cierre.periodo}"
 
     class Meta:
         unique_together = ("cierre", "empleado")


### PR DESCRIPTION
## Summary
- ensure RegistroNomina `__str__` uses `rut_trabajador`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840ff0cf2ec8323b54895043e871c6a