### PR TITLE
Fix header extraction in payroll book

### DIFF
--- a/backend/nomina/tests.py
+++ b/backend/nomina/tests.py
@@ -1,3 +1,27 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
+import pandas as pd
+from tempfile import NamedTemporaryFile
 
-# Create your tests here.
+from nomina.utils.LibroRemuneraciones import obtener_headers_libro_remuneraciones
+
+
+class ObtenerHeadersLibroRemuneracionesTests(SimpleTestCase):
+    def test_employee_columns_removed(self):
+        df = pd.DataFrame({
+            'A\u00d1O': [2024],
+            'MES': [5],
+            'RUT_EMPRESA': ['12345678-9'],
+            'RUT_TRABAJADOR': ['11111111'],
+            'DV_TRABAJADOR': ['1'],
+            'NOMBRES': ['Ana'],
+            'APELLIDO_PATERNO': ['Gomez'],
+            'APELLIDO_MATERNO': ['Luna'],
+            'SUELDO BASE': [1000],
+            'BONO': [100],
+        })
+        with NamedTemporaryFile(suffix='.xlsx') as tmp:
+            df.to_excel(tmp.name, index=False)
+            headers = obtener_headers_libro_remuneraciones(tmp.name)
+
+        self.assertEqual(headers, ['SUELDO BASE', 'BONO'])
+

--- a/backend/nomina/utils/LibroRemuneraciones.py
+++ b/backend/nomina/utils/LibroRemuneraciones.py
@@ -16,6 +16,7 @@ def obtener_headers_libro_remuneraciones(path_archivo):
         df = pd.read_excel(path_archivo, engine="openpyxl")
         headers = list(df.columns)
 
+        # --- Heuristics for common employee columns ---
         rut_col = next((c for c in headers if 'rut' in c.lower() and 'trab' in c.lower()), None)
         dv_col = next((c for c in headers if 'dv' in c.lower() and 'trab' in c.lower()), None)
         ape_pat_col = next((c for c in headers if 'apellido' in c.lower() and 'pater' in c.lower()), None)
@@ -23,7 +24,21 @@ def obtener_headers_libro_remuneraciones(path_archivo):
         nombres_col = next((c for c in headers if 'nombre' in c.lower()), None)
         ingreso_col = next((c for c in headers if 'ingreso' in c.lower()), None)
 
-        empleado_cols = {c for c in [rut_col, dv_col, ape_pat_col, ape_mat_col, nombres_col, ingreso_col] if c}
+        heuristic_cols = {c for c in [rut_col, dv_col, ape_pat_col, ape_mat_col, nombres_col, ingreso_col] if c}
+
+        # --- Explicit columns to drop regardless of heuristics ---
+        explicit_drop = {
+            'año',
+            'mes',
+            'rut_empresa',
+            'rut_trabajador',
+            'nombres',
+            'apellido_paterno',
+            'apellido_materno',
+        }
+        explicit_cols = {h for h in headers if h.strip().lower() in explicit_drop}
+
+        empleado_cols = heuristic_cols.union(explicit_cols)
         filtered_headers = [h for h in headers if h not in empleado_cols]
 
         logger.info(f"Headers encontrados: {filtered_headers}")


### PR DESCRIPTION
## Summary
- drop employee identification columns when reading payroll workbooks
- test header extraction ignores employee columns

## Testing
- `backend/venv/bin/python backend/manage.py test nomina -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6841c757c5dc8323928beab4c512375b