### PR TITLE
Fix payroll utils headers

### DIFF
--- a/backend/nomina/tests.py
+++ b/backend/nomina/tests.py
@@ -8,14 +8,14 @@ from nomina.utils.LibroRemuneraciones import obtener_headers_libro_remuneracione
 class ObtenerHeadersLibroRemuneracionesTests(SimpleTestCase):
     def test_employee_columns_removed(self):
         df = pd.DataFrame({
-            'A\u00d1O': [2024],
-            'MES': [5],
-            'RUT_EMPRESA': ['12345678-9'],
-            'RUT_TRABAJADOR': ['11111111'],
-            'DV_TRABAJADOR': ['1'],
-            'NOMBRES': ['Ana'],
-            'APELLIDO_PATERNO': ['Gomez'],
-            'APELLIDO_MATERNO': ['Luna'],
+            'Año': [2024],
+            'Mes': [5],
+            'Rut de la Empresa': ['12345678-9'],
+            'Rut del Trabajador': ['11111111'],
+            'DV Trabajador': ['1'],
+            'Nombre': ['Ana'],
+            'Apellido Paterno': ['Gomez'],
+            'Apellido Materno': ['Luna'],
             'SUELDO BASE': [1000],
             'BONO': [100],
         })

--- a/backend/nomina/utils/LibroRemuneraciones.py
+++ b/backend/nomina/utils/LibroRemuneraciones.py
@@ -30,11 +30,11 @@ def obtener_headers_libro_remuneraciones(path_archivo):
         explicit_drop = {
             'año',
             'mes',
-            'rut_empresa',
-            'rut_trabajador',
-            'nombres',
-            'apellido_paterno',
-            'apellido_materno',
+            'rut de la empresa',
+            'rut del trabajador',
+            'nombre',
+            'apellido paterno',
+            'apellido materno',
         }
         explicit_cols = {h for h in headers if h.strip().lower() in explicit_drop}
 


### PR DESCRIPTION
## Summary
- update libroRemuneraciones utils to drop new headers
- update payroll header test to use exact headers

## Testing
- `backend/venv/bin/python backend/manage.py test backend.nomina.tests.ObtenerHeadersLibroRemuneracionesTests.test_employee_columns_removed -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6841d29d04b08323b0e27f7c3f91419f