### PR TITLE
Add procesar action for libros remuneraciones

### DIFF
--- a/backend/nomina/urls.py
+++ b/backend/nomina/urls.py
@@ -30,6 +30,11 @@ router.register(r'registros-nomina', RegistroNominaViewSet, basename='registro-n
 
 urlpatterns = router.urls + [
     path(
+        'libros-remuneraciones/<int:pk>/procesar/',
+        LibroRemuneracionesUploadViewSet.as_view({'post': 'procesar'}),
+        name='procesar-libro-remuneraciones',
+    ),
+    path(
         'plantilla-libro-remuneraciones/',
         serve,
         {


### PR DESCRIPTION
## Summary
- add Celery chain task `procesar_libro_remuneraciones`
- expose `procesar` action on `LibroRemuneracionesUploadViewSet`
- register new route for the action

## Testing
- `backend/venv/bin/python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6841efa2921483238584dee0e374ebb4