### PR TITLE
Fix CierreNomina serializer field mismatch

### DIFF
--- a/backend/nomina/serializers.py
+++ b/backend/nomina/serializers.py
@@ -28,7 +28,7 @@ class CierreNominaSerializer(serializers.ModelSerializer):
     class Meta:
         model = CierreNomina
         fields = [
-            'id', 'cliente', 'periodo', 'usuario_analista', 'usuario_supervisor',
+            'id', 'cliente', 'periodo', 'usuario_analista',
             'estado', 'fecha_creacion', 'checklist'
         ]
 
@@ -37,7 +37,7 @@ class CierreNominaCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CierreNomina
-        fields = ['cliente', 'periodo', 'usuario_supervisor', 'checklist']
+        fields = ['cliente', 'periodo', 'checklist']
 
     def validate(self, data):
         cliente = data.get('cliente')


### PR DESCRIPTION
## Summary
- remove non-existent `usuario_supervisor` field from serializers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684269e6d0e8832383bc0eddd381579f