### PR TITLE
Add account analysis feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import HistorialCierresPage from "./pages/HistorialCierresPage";
 import CrearCierre from "./pages/CrearCierre";
 import CierreDetalle from "./pages/CierreDetalle"; // Asegúrate de importar la página de detalle del cierre
 import CierreDetalleNomina from "./pages/CierreDetalleNomina";
+import AnalisisCuentas from "./pages/AnalisisCuentas";
 
 function App() {
   return (
@@ -40,6 +41,7 @@ function App() {
 
           {/* ----------- ÁREA: CONTABILIDAD ------------- */}
           <Route path="cierres/:cierreId" element={<CierreDetalle />} />
+          <Route path="cierres/:cierreId/analisis" element={<AnalisisCuentas />} />
 
           {/* ----------- ÁREA: NÓMINA ------------- */}
           <Route path="nomina/cierres/:cierreId" element={<CierreDetalleNomina />} />

--- a/src/api/contabilidad.js
+++ b/src/api/contabilidad.js
@@ -224,4 +224,12 @@ export const subirNombresIngles = async (formData) => {
     headers: { "Content-Type": "multipart/form-data" }
   });
   return res.data; // { ok: true }
-}
+};
+
+// Resumen de movimientos por cuenta para un cierre
+export const obtenerMovimientosResumen = async (cierreId) => {
+  const res = await api.get(
+    `/contabilidad/cierres/${cierreId}/movimientos-resumen/`
+  );
+  return res.data;
+};

--- a/src/components/HistorialCierres.jsx
+++ b/src/components/HistorialCierres.jsx
@@ -65,9 +65,9 @@ const HistorialCierres = ({ clienteId, areaActiva }) => {
                   {cierre.estado === "completo" && areaActiva === "Contabilidad" && (
                     <button
                       className="text-green-500 underline font-medium"
-                      onClick={() => navigate(`/menu/cierres/${cierre.id}/informes`)}
+                      onClick={() => navigate(`/menu/cierres/${cierre.id}/analisis`)}
                     >
-                      Generar reportes
+                      Generar análisis de cuentas
                     </button>
                   )}
                   {/* Aquí puedes poner otras acciones para Nómina */}

--- a/src/pages/AnalisisCuentas.jsx
+++ b/src/pages/AnalisisCuentas.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import CierreInfoBar from "../components/InfoCards/CierreInfoBar";
+import { obtenerCierrePorId, obtenerMovimientosResumen } from "../api/contabilidad";
+import { obtenerCliente } from "../api/clientes";
+
+const AnalisisCuentas = () => {
+  const { cierreId } = useParams();
+  const [cierre, setCierre] = useState(null);
+  const [cliente, setCliente] = useState(null);
+  const [resumen, setResumen] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!cierreId) return;
+      const cierreObj = await obtenerCierrePorId(cierreId);
+      setCierre(cierreObj);
+      const clienteObj = await obtenerCliente(cierreObj.cliente);
+      setCliente(clienteObj);
+      const movResumen = await obtenerMovimientosResumen(cierreId);
+      setResumen(movResumen);
+    };
+    fetchData();
+  }, [cierreId]);
+
+  if (!cierre || !cliente || !resumen) {
+    return (
+      <div className="text-white text-center mt-8">Cargando análisis de cuentas...</div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <CierreInfoBar cierre={cierre} cliente={cliente} />
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-separate border-spacing-y-1">
+          <thead>
+            <tr className="bg-gray-700">
+              <th className="px-4 py-2 text-left">Cuenta</th>
+              <th className="px-4 py-2 text-right">Saldo anterior</th>
+              <th className="px-4 py-2 text-right">Total debe</th>
+              <th className="px-4 py-2 text-right">Total haber</th>
+              <th className="px-4 py-2 text-right">Saldo final</th>
+            </tr>
+          </thead>
+          <tbody>
+            {resumen.map((r) => (
+              <tr key={r.cuenta_id} className="bg-gray-800">
+                <td className="px-4 py-2">
+                  {r.codigo} - {r.nombre}
+                </td>
+                <td className="px-4 py-2 text-right">{r.saldo_anterior}</td>
+                <td className="px-4 py-2 text-right">{r.total_debe}</td>
+                <td className="px-4 py-2 text-right">{r.total_haber}</td>
+                <td className="px-4 py-2 text-right">{r.saldo_final}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default AnalisisCuentas;


### PR DESCRIPTION
## Summary
- support fetching account movement summaries
- create analysis page for monthly closures
- route `/menu/cierres/:cierreId/analisis` to new page
- update historial cierres button label and navigation

## Testing
- `npm run lint` *(fails: 1666 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6842696c75bc8323b016e1d0854d4692