### PR TITLE
Add filter panel for MovimientosCuenta

### DIFF
--- a/src/pages/MovimientosCuenta.jsx
+++ b/src/pages/MovimientosCuenta.jsx
@@ -9,6 +9,7 @@ const MovimientosCuenta = () => {
   const [cierre, setCierre] = useState(null);
   const [cliente, setCliente] = useState(null);
   const [detalle, setDetalle] = useState(null);
+  const [filtros, setFiltros] = useState({ desde: "", hasta: "", texto: "" });
 
   useEffect(() => {
     const fetchData = async () => {
@@ -24,8 +25,22 @@ const MovimientosCuenta = () => {
   }, [cierreId, cuentaId]);
 
   if (!cierre || !cliente || !detalle) {
-    return <div className="text-white text-center mt-8">Cargando movimientos...</div>;
+    return (
+      <div className="text-white text-center mt-8">Cargando movimientos...</div>
+    );
   }
+
+  const { desde, hasta, texto } = filtros;
+  const movimientosFiltrados = detalle.movimientos.filter((m) => {
+    if (desde && new Date(m.fecha) < new Date(desde)) return false;
+    if (hasta && new Date(m.fecha) > new Date(hasta)) return false;
+    if (
+      texto &&
+      !m.descripcion.toLowerCase().includes(texto.toLowerCase())
+    )
+      return false;
+    return true;
+  });
 
   return (
     <div className="space-y-6">
@@ -36,6 +51,47 @@ const MovimientosCuenta = () => {
       <h2 className="text-xl font-semibold text-white">
         {detalle.codigo} - {detalle.nombre}
       </h2>
+
+      <div className="bg-gray-800 p-4 rounded-md flex flex-col gap-4 md:flex-row md:items-end">
+        <div className="flex flex-col">
+          <label className="text-sm text-gray-300" htmlFor="desde">Desde</label>
+          <input
+            id="desde"
+            type="date"
+            className="bg-gray-700 text-white rounded px-2 py-1"
+            value={desde}
+            onChange={(e) =>
+              setFiltros((f) => ({ ...f, desde: e.target.value }))
+            }
+          />
+        </div>
+        <div className="flex flex-col">
+          <label className="text-sm text-gray-300" htmlFor="hasta">Hasta</label>
+          <input
+            id="hasta"
+            type="date"
+            className="bg-gray-700 text-white rounded px-2 py-1"
+            value={hasta}
+            onChange={(e) =>
+              setFiltros((f) => ({ ...f, hasta: e.target.value }))
+            }
+          />
+        </div>
+        <div className="flex flex-col flex-grow">
+          <label className="text-sm text-gray-300" htmlFor="texto">Buscar</label>
+          <input
+            id="texto"
+            type="text"
+            placeholder="Descripción..."
+            className="bg-gray-700 text-white rounded px-2 py-1"
+            value={texto}
+            onChange={(e) =>
+              setFiltros((f) => ({ ...f, texto: e.target.value }))
+            }
+          />
+        </div>
+      </div>
+
       <div className="overflow-x-auto">
         <table className="w-full text-sm border-separate border-spacing-y-1">
           <thead>
@@ -48,7 +104,11 @@ const MovimientosCuenta = () => {
             </tr>
           </thead>
           <tbody>
-            {detalle.movimientos.map((m) => (
+            <tr className="bg-gray-800 font-semibold">
+              <td colSpan={4} className="px-4 py-2 text-right">Saldo inicial</td>
+              <td className="px-4 py-2 text-right">{detalle.saldo_inicial}</td>
+            </tr>
+            {movimientosFiltrados.map((m) => (
               <tr key={m.id} className="bg-gray-800">
                 <td className="px-4 py-2">{m.fecha}</td>
                 <td className="px-4 py-2">{m.descripcion}</td>


### PR DESCRIPTION
## Summary
- add filter panel with date range and text search
- compute filtered movimientos with saldo inicial row
- update table to react to filters

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*
- `npx eslint src/pages/MovimientosCuenta.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68427a30ac6883238bb2c70497643f51