### PR TITLE
Add wrapper page for cierre classification

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Layout from "./components/Layout";
 import Clientes from "./pages/Clientes";
 import ClienteDetalle from "./pages/ClienteDetalle";
 import PaginaClasificacion from "./pages/PaginaClasificacion";
+import ClasificacionCierre from "./pages/ClasificacionCierre";
 import HistorialCierresPage from "./pages/HistorialCierresPage";
 import CrearCierre from "./pages/CrearCierre";
 import CierreDetalle from "./pages/CierreDetalle"; // Asegúrate de importar la página de detalle del cierre
@@ -43,6 +44,7 @@ function App() {
           {/* ----------- ÁREA: CONTABILIDAD ------------- */}
           <Route path="cierres/:cierreId" element={<CierreDetalle />} />
           <Route path="cierres/:cierreId/analisis" element={<AnalisisCuentas />} />
+          <Route path="cierres/:cierreId/clasificacion" element={<ClasificacionCierre />} />
           <Route
             path="cierres/:cierreId/cuentas/:cuentaId"
             element={<MovimientosCuenta />}

--- a/src/pages/ClasificacionCierre.jsx
+++ b/src/pages/ClasificacionCierre.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import PaginaClasificacion from "./PaginaClasificacion";
+import { obtenerCierrePorId } from "../api/contabilidad";
+
+const ClasificacionCierre = () => {
+  const { cierreId } = useParams();
+  const [clienteId, setClienteId] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!cierreId) return;
+      try {
+        const cierre = await obtenerCierrePorId(cierreId);
+        setClienteId(cierre.cliente);
+      } catch {
+        setClienteId(null);
+      }
+    };
+    fetchData();
+  }, [cierreId]);
+
+  if (!clienteId) {
+    return (
+      <div className="text-white text-center mt-8">Cargando clasificación...</div>
+    );
+  }
+
+  return <PaginaClasificacion clienteId={clienteId} />;
+};
+
+export default ClasificacionCierre;

--- a/src/pages/PaginaClasificacion.jsx
+++ b/src/pages/PaginaClasificacion.jsx
@@ -10,8 +10,9 @@ import {
   crearOpcionClasificacion,
 } from "../api/contabilidad";
 
-const PaginaClasificacion = () => {
-  const { clienteId } = useParams();
+const PaginaClasificacion = ({ clienteId: propClienteId }) => {
+  const { clienteId: paramClienteId } = useParams();
+  const clienteId = propClienteId || paramClienteId;
 
   const [sets, setSets] = useState([]);
   const [selectedSet, setSelectedSet] = useState(null);


### PR DESCRIPTION
## Summary
- add `ClasificacionCierre` wrapper page
- allow `PaginaClasificacion` to accept a `clienteId` prop
- route `/menu/cierres/:cierreId/clasificacion` to new page

## Testing
- `backend/venv/bin/python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68427a51fb3483239f97d954d7364e47