### PR TITLE
Support tree of classification options

### DIFF
--- a/src/api/contabilidad.js
+++ b/src/api/contabilidad.js
@@ -128,7 +128,11 @@ export const obtenerOpcionesClasificacion = async (setClasId) => {
   const res = await api.get(`/contabilidad/clasificaciones-opcion/`, {
     params: { set_clas: setClasId }
   });
-  return res.data;
+  // Garantiza que el campo parent se incluya siempre
+  return res.data.map((o) => ({
+    ...o,
+    parent: o.parent,
+  }));
 };
 
 


### PR DESCRIPTION
## Summary
- expose parent IDs for classification options
- render nested option tree on PaginaClasificacion
- allow creating suboptions via selected option

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68427d7fe07883239fe00707a610765d