### PR TITLE
Add filter and format numbers

### DIFF
--- a/src/components/ServiciosContratados.jsx
+++ b/src/components/ServiciosContratados.jsx
@@ -1,3 +1,5 @@
+import { formatMoney } from "../utils/format";
+
 const ServiciosContratados = ({ servicios, areaActiva }) => {
   // Filtra los servicios que correspondan solo al área activa
   const serviciosFiltrados = areaActiva
@@ -16,7 +18,7 @@ const ServiciosContratados = ({ servicios, areaActiva }) => {
         <ul className="list-disc list-inside space-y-2">
           {serviciosFiltrados.map((s) => (
             <li key={s.id} className="text-white">
-              {s.servicio_nombre || "—"} — {s.valor} {s.moneda}
+              {s.servicio_nombre || "—"} — {formatMoney(s.valor)} {s.moneda}
             </li>
           ))}
         </ul>

--- a/src/pages/AnalisisCuentas.jsx
+++ b/src/pages/AnalisisCuentas.jsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import CierreInfoBar from "../components/InfoCards/CierreInfoBar";
-import { obtenerCierrePorId, obtenerMovimientosResumen } from "../api/contabilidad";
+import {
+  obtenerCierrePorId,
+  obtenerMovimientosResumen,
+} from "../api/contabilidad";
 import { obtenerCliente } from "../api/clientes";
+import { formatMoney } from "../utils/format";
 
 const AnalisisCuentas = () => {
   const { cierreId } = useParams();
@@ -10,6 +14,7 @@ const AnalisisCuentas = () => {
   const [cierre, setCierre] = useState(null);
   const [cliente, setCliente] = useState(null);
   const [resumen, setResumen] = useState(null);
+  const [filtros, setFiltros] = useState({ texto: "" });
 
   useEffect(() => {
     const fetchData = async () => {
@@ -30,9 +35,29 @@ const AnalisisCuentas = () => {
     );
   }
 
+  const { texto } = filtros;
+  const resumenFiltrado = resumen.filter((r) =>
+    `${r.codigo} ${r.nombre}`.toLowerCase().includes(texto.toLowerCase())
+  );
+
   return (
     <div className="space-y-6">
       <CierreInfoBar cierre={cierre} cliente={cliente} />
+      <div className="bg-gray-800 p-4 rounded-md flex flex-col gap-4 md:flex-row md:items-end">
+        <div className="flex flex-col flex-grow">
+          <label className="text-sm text-gray-300" htmlFor="texto">Buscar</label>
+          <input
+            id="texto"
+            type="text"
+            placeholder="Cuenta..."
+            className="bg-gray-700 text-white rounded px-2 py-1"
+            value={texto}
+            onChange={(e) =>
+              setFiltros((f) => ({ ...f, texto: e.target.value }))
+            }
+          />
+        </div>
+      </div>
       <div className="overflow-x-auto">
         <table className="w-full text-sm border-separate border-spacing-y-1">
           <thead>
@@ -45,7 +70,7 @@ const AnalisisCuentas = () => {
             </tr>
           </thead>
           <tbody>
-            {resumen.map((r) => (
+            {resumenFiltrado.map((r) => (
               <tr
                 key={r.cuenta_id}
                 className="bg-gray-800 hover:bg-gray-700 cursor-pointer"
@@ -56,10 +81,10 @@ const AnalisisCuentas = () => {
                 <td className="px-4 py-2">
                   {r.codigo} - {r.nombre}
                 </td>
-                <td className="px-4 py-2 text-right">{r.saldo_anterior}</td>
-                <td className="px-4 py-2 text-right">{r.total_debe}</td>
-                <td className="px-4 py-2 text-right">{r.total_haber}</td>
-                <td className="px-4 py-2 text-right">{r.saldo_final}</td>
+                <td className="px-4 py-2 text-right">{formatMoney(r.saldo_anterior)}</td>
+                <td className="px-4 py-2 text-right">{formatMoney(r.total_debe)}</td>
+                <td className="px-4 py-2 text-right">{formatMoney(r.total_haber)}</td>
+                <td className="px-4 py-2 text-right">{formatMoney(r.saldo_final)}</td>
               </tr>
             ))}
           </tbody>

--- a/src/pages/MovimientosCuenta.jsx
+++ b/src/pages/MovimientosCuenta.jsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import CierreInfoBar from "../components/InfoCards/CierreInfoBar";
-import { obtenerCierrePorId, obtenerMovimientosCuenta } from "../api/contabilidad";
+import {
+  obtenerCierrePorId,
+  obtenerMovimientosCuenta,
+} from "../api/contabilidad";
 import { obtenerCliente } from "../api/clientes";
+import { formatMoney } from "../utils/format";
 
 const MovimientosCuenta = () => {
   const { cierreId, cuentaId } = useParams();
@@ -106,15 +110,15 @@ const MovimientosCuenta = () => {
           <tbody>
             <tr className="bg-gray-800 font-semibold">
               <td colSpan={4} className="px-4 py-2 text-right">Saldo inicial</td>
-              <td className="px-4 py-2 text-right">{detalle.saldo_inicial}</td>
+              <td className="px-4 py-2 text-right">{formatMoney(detalle.saldo_inicial)}</td>
             </tr>
             {movimientosFiltrados.map((m) => (
               <tr key={m.id} className="bg-gray-800">
                 <td className="px-4 py-2">{m.fecha}</td>
                 <td className="px-4 py-2">{m.descripcion}</td>
-                <td className="px-4 py-2 text-right">{m.debe}</td>
-                <td className="px-4 py-2 text-right">{m.haber}</td>
-                <td className="px-4 py-2 text-right">{m.saldo}</td>
+                <td className="px-4 py-2 text-right">{formatMoney(m.debe)}</td>
+                <td className="px-4 py-2 text-right">{formatMoney(m.haber)}</td>
+                <td className="px-4 py-2 text-right">{formatMoney(m.saldo)}</td>
               </tr>
             ))}
           </tbody>

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,0 +1,7 @@
+export const formatMoney = (num) => {
+  if (num === null || num === undefined) return '';
+  return new Intl.NumberFormat('es-CL', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Number(num));
+};


### PR DESCRIPTION
## Summary
- filter account list by name/code in AnalisisCuentas
- show money values with Chilean format in AnalisisCuentas, MovimientosCuenta and ServiciosContratados
- provide `formatMoney` utility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `backend/venv/bin/python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684282544a5083239ffc6267218d9917