### PR TITLE
Add classification filters to movimientos resumen

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,15 @@ crear `Empleado` (RUT, DV, nombres, apellidos y fecha de ingreso) no aparezcan e
 Cada fila del Libro de Remuneraciones se almacena en el modelo `RegistroNomina`.
 Los valores se guardan en el campo JSON `data` y pueden consultarse a través del
 endpoint `/registros-nomina/`.
+
+### Filtro de movimientos por clasificación
+
+El endpoint `/contabilidad/cierres/<id>/movimientos-resumen/` acepta los
+parámetros opcionales `set_id` y `opcion_id` para filtrar las cuentas según su
+clasificación. Ejemplo:
+
+```
+/api/contabilidad/cierres/1/movimientos-resumen/?set_id=2&opcion_id=5
+```
+
+Retorna únicamente las cuentas que estén clasificadas con la opción indicada.

--- a/src/api/contabilidad.js
+++ b/src/api/contabilidad.js
@@ -231,9 +231,16 @@ export const subirNombresIngles = async (formData) => {
 };
 
 // Resumen de movimientos por cuenta para un cierre
-export const obtenerMovimientosResumen = async (cierreId) => {
+export const obtenerMovimientosResumen = async (
+  cierreId,
+  { setId, opcionId } = {}
+) => {
+  const params = {};
+  if (setId) params.set_id = setId;
+  if (opcionId) params.opcion_id = opcionId;
   const res = await api.get(
-    `/contabilidad/cierres/${cierreId}/movimientos-resumen/`
+    `/contabilidad/cierres/${cierreId}/movimientos-resumen/`,
+    { params }
   );
   return res.data;
 };


### PR DESCRIPTION
## Summary
- allow filtering movimientos resumen by classification set/option
- expose classification in summary endpoint
- forward filter params in API helper
- fetch classification options in AnalisisCuentas and add filter UI
- test classification filters
- document new query parameters

## Testing
- `backend/venv/bin/python backend/manage.py test contabilidad -v 2` *(fails: OperationalError could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_684292396658832397835e965992db85