### PR TITLE
Use env vars for Django secret key and debug

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for development
+SECRET_KEY=changeme
+DEBUG=false
+VITE_API_BASE=http://localhost:8000

--- a/backend/sgm_backend/settings.py
+++ b/backend/sgm_backend/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 from pathlib import Path
 from datetime import timedelta
 from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
 import os
 
 CELERY_BROKER_URL = os.environ.get('REDIS_URL', 'redis://redis:6379/0')
@@ -33,10 +34,12 @@ MEDIA_URL = "/media/"
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-u2#(sazu4(@)5m#^p_sns-v*dfa7+m&q9q4%5b0-@%+f4a39)4'
+SECRET_KEY = os.environ.get("SECRET_KEY")
+if not SECRET_KEY:
+    raise ImproperlyConfigured("SECRET_KEY environment variable is required")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get("DEBUG", "False").lower() in {"1", "true", "yes", "y"}
 
 ALLOWED_HOSTS = ['172.17.11.18']
 


### PR DESCRIPTION
## Summary
- read SECRET_KEY and DEBUG from environment in settings
- add .env.example documenting SECRET_KEY and DEBUG

## Testing
- `backend/venv/bin/python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6844f3b1f64483238c913ecc4e3a8f28