### PR TITLE
Add usuario_clasifica field

### DIFF
--- a/backend/nomina/admin.py
+++ b/backend/nomina/admin.py
@@ -24,7 +24,13 @@ class EmpleadoCierreAdmin(admin.ModelAdmin):
 
 @admin.register(ConceptoRemuneracion)
 class ConceptoRemuneracionAdmin(admin.ModelAdmin):
-    list_display = ('cliente', 'nombre_concepto', 'clasificacion', 'vigente')
+    list_display = (
+        'cliente',
+        'nombre_concepto',
+        'clasificacion',
+        'usuario_clasifica',
+        'vigente',
+    )
     list_filter = ('cliente', 'clasificacion', 'vigente')
     search_fields = ('cliente__nombre', 'nombre_concepto')
 

--- a/backend/nomina/migrations/0002_conceptoremuneracion_usuario_clasifica.py
+++ b/backend/nomina/migrations/0002_conceptoremuneracion_usuario_clasifica.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nomina', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='conceptoremuneracion',
+            name='usuario_clasifica',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='conceptos_clasificados', to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/backend/nomina/models.py
+++ b/backend/nomina/models.py
@@ -74,6 +74,13 @@ class ConceptoRemuneracion(models.Model):
     nombre_concepto = models.CharField(max_length=120)
     clasificacion = models.CharField(max_length=20, choices=CLASIFICACION_CHOICES)
     hashtags = models.JSONField(default=list, blank=True)
+    usuario_clasifica = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="conceptos_clasificados",
+    )
     vigente = models.BooleanField(default=True)
 
     class Meta:

--- a/backend/nomina/serializers.py
+++ b/backend/nomina/serializers.py
@@ -65,7 +65,7 @@ class EmpleadoCierreSerializer(serializers.ModelSerializer):
 class ConceptoRemuneracionSerializer(serializers.ModelSerializer):
     class Meta:
         model = ConceptoRemuneracion
-        fields = ['nombre_concepto', 'clasificacion', 'hashtags']
+        fields = ['nombre_concepto', 'clasificacion', 'hashtags', 'usuario_clasifica']
 
 class RegistroConceptoEmpleadoSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
## Summary
- track user who classifies a concept
- include usuario_clasifica in API serializer
- show the user in Django admin
- migration for the new field

## Testing
- `python manage.py makemigrations nomina` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test nomina` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6846fc676e1c8323b11d074017d9d06b