### PR TITLE
Fix payroll records save logic

### DIFF
--- a/backend/nomina/tasks.py
+++ b/backend/nomina/tasks.py
@@ -1,60 +1,76 @@
-#nomina/tasks.py
-from .utils.LibroRemuneraciones import obtener_headers_libro_remuneraciones, clasificar_headers_libro_remuneraciones
+# nomina/tasks.py
+from .utils.LibroRemuneraciones import (
+    obtener_headers_libro_remuneraciones,
+    clasificar_headers_libro_remuneraciones,
+)
 from celery import shared_task, chain
-from .models import LibroRemuneracionesUpload, EmpleadoCierre, RegistroConceptoEmpleado
+from .models import (
+    LibroRemuneracionesUpload,
+    EmpleadoCierre,
+    RegistroConceptoEmpleado,
+    ConceptoRemuneracion,
+)
 import logging
 import pandas as pd
 
 logger = logging.getLogger(__name__)
 
+
 @shared_task
 def analizar_headers_libro_remuneraciones(libro_id):
     logger.info(f"Procesando libro de remuneraciones id={libro_id}")
     libro = LibroRemuneracionesUpload.objects.get(id=libro_id)
-    libro.estado = 'analizando_hdrs'
+    libro.estado = "analizando_hdrs"
     libro.save()
 
     try:
         headers = obtener_headers_libro_remuneraciones(libro.archivo.path)
         libro.header_json = headers
-        libro.estado = 'hdrs_analizados'
+        libro.estado = "hdrs_analizados"
         libro.save()
         logger.info(f"Procesamiento exitoso libro id={libro_id}")
         # ¡Retornamos libro_id y headers!
-        return {'libro_id': libro_id, 'headers': headers}
+        return {"libro_id": libro_id, "headers": headers}
     except Exception as e:
-        libro.estado = 'con_error'
+        libro.estado = "con_error"
         libro.save()
         logger.error(f"Error procesando libro id={libro_id}: {e}")
         raise
 
+
 @shared_task
 def clasificar_headers_libro_remuneraciones_task(result):
-    libro_id = result['libro_id']
+    libro_id = result["libro_id"]
     try:
         libro = LibroRemuneracionesUpload.objects.get(id=libro_id)
         cierre = libro.cierre
         cliente = cierre.cliente
 
         # Marcamos estado "en proceso de clasificación"
-        libro.estado = 'clasif_en_proceso'
+        libro.estado = "clasif_en_proceso"
         libro.save()
 
-        headers = libro.header_json if isinstance(libro.header_json, list) else result['headers']
+        headers = (
+            libro.header_json
+            if isinstance(libro.header_json, list)
+            else result["headers"]
+        )
 
-        headers_clasificados, headers_sin_clasificar = clasificar_headers_libro_remuneraciones(headers, cliente)
+        headers_clasificados, headers_sin_clasificar = (
+            clasificar_headers_libro_remuneraciones(headers, cliente)
+        )
 
         # Escribe el resultado final en el campo JSON
         libro.header_json = {
             "headers_clasificados": headers_clasificados,
-            "headers_sin_clasificar": headers_sin_clasificar
+            "headers_sin_clasificar": headers_sin_clasificar,
         }
 
         # Cambia el estado según si quedan pendientes o no
         if headers_sin_clasificar:
-            libro.estado = 'clasif_pendiente'
+            libro.estado = "clasif_pendiente"
         else:
-            libro.estado = 'clasificado'
+            libro.estado = "clasificado"
 
         libro.save()
         logger.info(
@@ -64,23 +80,25 @@ def clasificar_headers_libro_remuneraciones_task(result):
         return {
             "libro_id": libro_id,
             "headers_clasificados": len(headers_clasificados),
-            "headers_sin_clasificar": len(headers_sin_clasificar)
+            "headers_sin_clasificar": len(headers_sin_clasificar),
         }
     except Exception as e:
         logger.error(f"Error clasificando headers para libro id={libro_id}: {e}")
         # Intenta dejar el libro en estado error, pero no interrumpe la excepción.
         try:
             libro = LibroRemuneracionesUpload.objects.get(id=libro_id)
-            libro.estado = 'con_error'
+            libro.estado = "con_error"
             libro.save()
         except Exception as ex:
-            logger.error(f"Error guardando estado 'con_error' para libro id={libro_id}: {ex}")
+            logger.error(
+                f"Error guardando estado 'con_error' para libro id={libro_id}: {ex}"
+            )
         raise
 
 
 @shared_task
 def actualizar_empleados_desde_libro(result):
-    libro_id = result.get('libro_id') if isinstance(result, dict) else result
+    libro_id = result.get("libro_id") if isinstance(result, dict) else result
     try:
         libro = LibroRemuneracionesUpload.objects.get(id=libro_id)
         df = pd.read_excel(libro.archivo.path, engine="openpyxl")
@@ -103,26 +121,23 @@ def actualizar_empleados_desde_libro(result):
         primera_col = df.columns[0]
         count = 0
         for _, row in df.iterrows():
-            if not str(row.get(primera_col, '')).strip():
+            if not str(row.get(primera_col, "")).strip():
                 continue
             rut = str(row.get(expected["rut_trabajador"], "")).strip()
             defaults = {
-                'cliente': cierre.cliente,
-                'ano': int(row.get(expected["ano"], 0)),
-                'mes': int(row.get(expected["mes"], 0)),
-                'rut_empresa': str(row.get(expected["rut_empresa"], "")).strip(),
-                'nombre': str(row.get(expected["nombre"], '')).strip(),
-                'apellido_paterno': str(row.get(expected["ape_pat"], '')).strip(),
-                'apellido_materno': str(row.get(expected["ape_mat"], '')).strip(),
+                "rut_empresa": str(row.get(expected["rut_empresa"], "")).strip(),
+                "nombre": str(row.get(expected["nombre"], "")).strip(),
+                "apellido_paterno": str(row.get(expected["ape_pat"], "")).strip(),
+                "apellido_materno": str(row.get(expected["ape_mat"], "")).strip(),
             }
             EmpleadoCierre.objects.update_or_create(
                 cierre=cierre,
-                rut_trabajador=rut,
+                rut=rut,
                 defaults=defaults,
             )
             count += 1
         logger.info(f"Actualizados {count} empleados desde libro {libro_id}")
-        return {'libro_id': libro_id, 'empleados_actualizados': count}
+        return {"libro_id": libro_id, "empleados_actualizados": count}
     except Exception as e:
         logger.error(f"Error actualizando empleados para libro id={libro_id}: {e}")
         raise
@@ -130,7 +145,7 @@ def actualizar_empleados_desde_libro(result):
 
 @shared_task
 def guardar_registros_nomina(result):
-    libro_id = result.get('libro_id') if isinstance(result, dict) else result
+    libro_id = result.get("libro_id") if isinstance(result, dict) else result
     try:
         libro = LibroRemuneracionesUpload.objects.get(id=libro_id)
         df = pd.read_excel(libro.archivo.path, engine="openpyxl")
@@ -153,32 +168,42 @@ def guardar_registros_nomina(result):
 
         headers = libro.header_json
         if isinstance(headers, dict):
-            headers = headers.get("headers_clasificados", []) + headers.get("headers_sin_clasificar", [])
+            headers = headers.get("headers_clasificados", []) + headers.get(
+                "headers_sin_clasificar", []
+            )
         if not headers:
             headers = [h for h in df.columns if h not in empleado_cols]
 
         primera_col = df.columns[0]
         count = 0
         for _, row in df.iterrows():
-            if not str(row.get(primera_col, '')).strip():
+            if not str(row.get(primera_col, "")).strip():
                 continue
             rut = str(row.get(expected["rut_trabajador"], "")).strip()
-            empleado = EmpleadoCierre.objects.filter(cierre=libro.cierre, rut_trabajador=rut).first()
+            empleado = EmpleadoCierre.objects.filter(
+                cierre=libro.cierre, rut=rut
+            ).first()
             if not empleado:
                 continue
 
-            data = {h: row.get(h) for h in headers}
-            RegistroConceptoEmpleado.objects.update_or_create(
-                cierre=libro.cierre,
-                empleado=empleado,
-                defaults={"data": data},
-            )
+            for h in headers:
+                monto = row.get(h)
+                concepto = ConceptoRemuneracion.objects.filter(
+                    cliente=libro.cierre.cliente, nombre_concepto=h, vigente=True
+                ).first()
+                RegistroConceptoEmpleado.objects.update_or_create(
+                    empleado=empleado,
+                    nombre_concepto_original=h,
+                    defaults={"monto": monto, "concepto": concepto},
+                )
             count += 1
 
         logger.info(f"Registros nómina guardados desde libro {libro_id}: {count}")
         return {"libro_id": libro_id, "registros_actualizados": count}
     except Exception as e:
-        logger.error(f"Error guardando registros de nómina para libro id={libro_id}: {e}")
+        logger.error(
+            f"Error guardando registros de nómina para libro id={libro_id}: {e}"
+        )
         raise
 
 

--- a/backend/nomina/tests.py
+++ b/backend/nomina/tests.py
@@ -1,4 +1,14 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
+from django.core.files.uploadedfile import SimpleUploadedFile
+from nomina.models import (
+    Cliente,
+    CierreNomina,
+    LibroRemuneracionesUpload,
+    EmpleadoCierre,
+    ConceptoRemuneracion,
+    RegistroConceptoEmpleado,
+)
+from nomina.tasks import actualizar_empleados_desde_libro, guardar_registros_nomina
 import pandas as pd
 from tempfile import NamedTemporaryFile
 
@@ -7,21 +17,70 @@ from nomina.utils.LibroRemuneraciones import obtener_headers_libro_remuneracione
 
 class ObtenerHeadersLibroRemuneracionesTests(SimpleTestCase):
     def test_employee_columns_removed(self):
-        df = pd.DataFrame({
-            'Año': [2024],
-            'Mes': [5],
-            'Rut de la Empresa': ['12345678-9'],
-            'Rut del Trabajador': ['11111111'],
-            'DV Trabajador': ['1'],
-            'Nombre': ['Ana'],
-            'Apellido Paterno': ['Gomez'],
-            'Apellido Materno': ['Luna'],
-            'SUELDO BASE': [1000],
-            'BONO': [100],
-        })
-        with NamedTemporaryFile(suffix='.xlsx') as tmp:
+        df = pd.DataFrame(
+            {
+                "Año": [2024],
+                "Mes": [5],
+                "Rut de la Empresa": ["12345678-9"],
+                "Rut del Trabajador": ["11111111"],
+                "DV Trabajador": ["1"],
+                "Nombre": ["Ana"],
+                "Apellido Paterno": ["Gomez"],
+                "Apellido Materno": ["Luna"],
+                "SUELDO BASE": [1000],
+                "BONO": [100],
+            }
+        )
+        with NamedTemporaryFile(suffix=".xlsx") as tmp:
             df.to_excel(tmp.name, index=False)
             headers = obtener_headers_libro_remuneraciones(tmp.name)
 
-        self.assertEqual(headers, ['SUELDO BASE', 'BONO'])
+        self.assertEqual(headers, ["SUELDO BASE", "BONO"])
 
+
+class GuardarRegistrosNominaTests(TestCase):
+    databases = {"default"}
+
+    def setUp(self):
+        self.cliente = Cliente.objects.create(nombre="Test")
+        self.cierre = CierreNomina.objects.create(
+            cliente=self.cliente, periodo="2025-01"
+        )
+
+        df = pd.DataFrame(
+            {
+                "Año": [2025],
+                "Mes": [1],
+                "Rut de la Empresa": ["12345678-9"],
+                "Rut del Trabajador": ["11111111"],
+                "Nombre": ["Ana"],
+                "Apellido Paterno": ["Gomez"],
+                "Apellido Materno": ["Luna"],
+                "SUELDO BASE": [1000],
+            }
+        )
+        with NamedTemporaryFile(suffix=".xlsx", delete=False) as tmp:
+            df.to_excel(tmp.name, index=False)
+            tmp.seek(0)
+            content = tmp.read()
+
+        upload = SimpleUploadedFile("libro.xlsx", content)
+        self.libro = LibroRemuneracionesUpload.objects.create(
+            cierre=self.cierre,
+            archivo=upload,
+            header_json=["SUELDO BASE"],
+        )
+
+    def test_tasks_create_registros(self):
+        actualizar_empleados_desde_libro({"libro_id": self.libro.id})
+        ConceptoRemuneracion.objects.create(
+            cliente=self.cliente, nombre_concepto="SUELDO BASE", clasificacion="haber"
+        )
+        guardar_registros_nomina({"libro_id": self.libro.id})
+
+        empleado = EmpleadoCierre.objects.get(cierre=self.cierre, rut="11111111")
+        registro = RegistroConceptoEmpleado.objects.get(
+            empleado=empleado, nombre_concepto_original="SUELDO BASE"
+        )
+        self.assertEqual(registro.monto, 1000)
+        self.assertIsNotNone(registro.concepto)


### PR DESCRIPTION
## Summary
- fix `update_or_create` logic for employees and payroll records
- use `rut` field when matching employees
- expand test suite for payroll tasks

## Testing
- `venv/bin/python manage.py test nomina` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_6846fed371388323bb99a9e13159505b