### PR TITLE
Add polling and state updates for Libro Remuneraciones

### DIFF
--- a/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
+++ b/src/components/TarjetasCierreNomina/CierreProgresoNomina.jsx
@@ -78,9 +78,11 @@ const CierreProgresoNomina = ({ cierre, cliente }) => {
     const sinClasificar = Array.isArray(libro?.header_json?.headers_sin_clasificar)
       ? libro.header_json.headers_sin_clasificar.length === 0
       : false;
-    if (sinClasificar && !libroListo) {
+    const enProceso = libro?.estado === "procesando" || libro?.estado === "procesado";
+
+    if (sinClasificar && !enProceso && !libroListo) {
       setLibroListo(true);
-    } else if (!sinClasificar && libroListo) {
+    } else if ((!sinClasificar || enProceso) && libroListo) {
       setLibroListo(false);
     }
   }, [libro, libroListo]);
@@ -134,10 +136,11 @@ const CierreProgresoNomina = ({ cierre, cliente }) => {
       console.log('🔄 Llamando a procesarLibroRemuneraciones...');
       
       // FORZAR el estado a "procesando" ANTES de la llamada
-      setLibro(prev => ({ 
-        ...prev, 
-        estado: "procesando" 
+      setLibro(prev => ({
+        ...prev,
+        estado: "procesando"
       }));
+      setLibroListo(false); // asegura que la tarjeta muestre el estado de procesamiento
       
       await procesarLibroRemuneraciones(id);
       console.log('✅ Procesamiento iniciado - el polling monitoreará el progreso');
@@ -213,7 +216,11 @@ const CierreProgresoNomina = ({ cierre, cliente }) => {
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       <LibroRemuneracionesCard
         estado={
-          libroListo ? "clasificado" : libro?.estado || "no_subido"
+          libro?.estado === "procesando" || libro?.estado === "procesado"
+            ? libro?.estado
+            : libroListo
+            ? "clasificado"
+            : libro?.estado || "no_subido"
         }
         archivoNombre={libro?.archivo_nombre}
         subiendo={subiendo}

--- a/src/components/TarjetasCierreNomina/LibroRemuneracionesCard.jsx
+++ b/src/components/TarjetasCierreNomina/LibroRemuneracionesCard.jsx
@@ -51,7 +51,7 @@ const LibroRemuneracionesCard = ({
         } catch (pollError) {
           console.error(`❌ Error en polling #${contadorPolling}:`, pollError);
         }
-      }, 5000);
+      }, 40000); // consultar cada 40 segundos
       
     } else if (estado !== "procesando" && pollingRef.current) {
       console.log(`✅ Estado cambió a "${estado}" - deteniendo polling`);


### PR DESCRIPTION
## Summary
- poll libro remuneraciones processing state every 40 seconds
- keep `estado` as `procesando` while polling
- avoid showing "clasificado" while in processing or processed state

## Testing
- `backend/venv/bin/python backend/manage.py test` *(fails: SECRET_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68473cb18f3083238e6a8aaff5684dcf