### PR TITLE
Expose concept id in remuneration serializer

### DIFF
--- a/backend/nomina/serializers.py
+++ b/backend/nomina/serializers.py
@@ -68,7 +68,7 @@ class EmpleadoCierreSerializer(serializers.ModelSerializer):
 class ConceptoRemuneracionSerializer(serializers.ModelSerializer):
     class Meta:
         model = ConceptoRemuneracion
-        fields = ['nombre_concepto', 'clasificacion', 'hashtags', 'usuario_clasifica']
+        fields = ['id', 'nombre_concepto', 'clasificacion', 'hashtags', 'usuario_clasifica']
 
 class RegistroConceptoEmpleadoSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
## Summary
- include `id` field in `ConceptoRemuneracionSerializer`

## Testing
- `python3 backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684a007f75088323867f35b3d6c5c94e