### PR TITLE
Support unassigned mappings for novedades headers

### DIFF
--- a/backend/nomina/serializers.py
+++ b/backend/nomina/serializers.py
@@ -183,11 +183,15 @@ class ConceptoRemuneracionNovedadesSerializer(serializers.ModelSerializer):
     clasificacion = serializers.CharField(read_only=True)  # Viene del concepto del libro
     hashtags = serializers.JSONField(read_only=True)  # Viene del concepto del libro
     
+    concepto_libro = serializers.PrimaryKeyRelatedField(
+        queryset=ConceptoRemuneracion.objects.all(), allow_null=True, required=False
+    )
+
     class Meta:
         model = ConceptoRemuneracionNovedades
         fields = [
             'id', 'nombre_concepto_novedades', 'concepto_libro', 'concepto_libro_nombre',
-            'clasificacion', 'hashtags', 'activo', 'cliente', 'usuario_mapea', 
+            'clasificacion', 'hashtags', 'activo', 'cliente', 'usuario_mapea',
             'usuario_mapea_nombre', 'fecha_mapeo'
         ]
         read_only_fields = ['cliente', 'usuario_mapea', 'fecha_mapeo', 'clasificacion', 'hashtags']

--- a/src/api/nomina.js
+++ b/src/api/nomina.js
@@ -212,9 +212,14 @@ export const obtenerHeadersNovedades = async (archivoId) => {
 };
 
 export const mapearHeadersNovedades = async (archivoId, mapeos) => {
-  const response = await api.post(`/nomina/archivos-novedades/${archivoId}/clasificar_headers/`, {
-    mapeos
-  });
+  const payload = mapeos.map(m => ({
+    ...m,
+    concepto_libro_id: m.concepto_libro_id ?? null,
+  }));
+  const response = await api.post(
+    `/nomina/archivos-novedades/${archivoId}/clasificar_headers/`,
+    { mapeos: payload }
+  );
   return response.data;
 };
 


### PR DESCRIPTION
## Summary
- allow null concept mapping in API call `mapearHeadersNovedades`
- enable selecting "Sin asignación" in `ModalMapeoNovedades`
- handle null mappings in backend `clasificar_headers`
- expose nullable `concepto_libro` through serializer

## Testing
- `npm run lint`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a03ee879c8323be2fc3ee593ac324