### PR TITLE
Fix concepto libro references

### DIFF
--- a/backend/nomina/models.py
+++ b/backend/nomina/models.py
@@ -383,7 +383,8 @@ class ConceptoRemuneracionNovedades(models.Model):
         unique_together = ('cliente', 'nombre_concepto_novedades')
 
     def __str__(self):
-        return f"{self.cliente.nombre}: {self.nombre_concepto_novedades} → {self.concepto_libro.nombre_concepto}"
+        nombre = self.concepto_libro.nombre_concepto if self.concepto_libro else "Sin asignación"
+        return f"{self.cliente.nombre}: {self.nombre_concepto_novedades} → {nombre}"
     
     # Propiedades que delegan al concepto del libro
     @property

--- a/backend/nomina/views.py
+++ b/backend/nomina/views.py
@@ -638,7 +638,7 @@ class ArchivoNovedadesUploadViewSet(viewsets.ModelViewSet):
                 if mapeo.concepto_libro:
                     mapeos_existentes[mapeo.nombre_concepto_novedades] = {
                         'concepto_libro_id': mapeo.concepto_libro.id,
-                        'concepto_libro_nombre': mapeo.concepto_libro.nombre,
+                        'concepto_libro_nombre': mapeo.concepto_libro.nombre_concepto,
                         'concepto_libro_clasificacion': mapeo.concepto_libro.clasificacion,
                     }
                 else:


### PR DESCRIPTION
## Summary
- use `nombre_concepto` when exposing mapped conceptos in novedades headers
- guard against missing `concepto_libro` when printing `ConceptoRemuneracionNovedades`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684a095a06588323a6954b68c58adbba