### PR TITLE
Add manager performance endpoint

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -98,3 +98,17 @@ class AsignacionClienteUsuarioSerializer(serializers.ModelSerializer):
         read_only_fields = ['id', 'fecha_asignacion']
 
 
+class AnalistaPerformanceSerializer(serializers.ModelSerializer):
+    clientes_asignados = serializers.IntegerField(read_only=True)
+    cierres_contabilidad = serializers.IntegerField(read_only=True)
+    cierres_nomina = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = Usuario
+        fields = [
+            'id', 'nombre', 'apellido', 'correo_bdo', 'cargo_bdo',
+            'clientes_asignados', 'cierres_contabilidad', 'cierres_nomina'
+        ]
+        read_only_fields = fields
+
+

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -2,7 +2,8 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import (
     AreaViewSet, UsuarioViewSet, ClienteViewSet,
-    ServicioViewSet, ServicioClienteViewSet, ContratoViewSet, AsignacionClienteUsuarioViewSet, ping
+    ServicioViewSet, ServicioClienteViewSet, ContratoViewSet,
+    AsignacionClienteUsuarioViewSet, AnalistaPerformanceViewSet, ping,
 )
 
 router = DefaultRouter()
@@ -13,6 +14,7 @@ router.register(r'usuarios', UsuarioViewSet)
 router.register(r'servicio-clientes', ServicioClienteViewSet, basename='servicio-cliente')
 router.register(r'contratos', ContratoViewSet)
 router.register(r'asignaciones', AsignacionClienteUsuarioViewSet, basename='asignaciones')
+router.register(r'bi-analistas', AnalistaPerformanceViewSet, basename='bi-analistas')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import CierreDetalle from "./pages/CierreDetalle"; // Asegúrate de importar la 
 import CierreDetalleNomina from "./pages/CierreDetalleNomina";
 import AnalisisLibro from "./pages/AnalisisLibro";
 import MovimientosCuenta from "./pages/MovimientosCuenta";
+import InformesAnalistas from "./pages/InformesAnalistas";
 
 function App() {
   return (
@@ -52,6 +53,9 @@ function App() {
 
           {/* ----------- ÁREA: NÓMINA ------------- */}
           <Route path="nomina/cierres/:cierreId" element={<CierreDetalleNomina />} />
+
+          {/* ----------- ÁREA: INFORMES ------------- */}
+          <Route path="informes" element={<InformesAnalistas />} />
 
           {/* ----------- 404 / OTRAS ------------- */}
           <Route path="*" element={<h1 className="text-white">404 - Página no encontrada</h1>} />

--- a/src/api/analistas.js
+++ b/src/api/analistas.js
@@ -1,0 +1,6 @@
+import api from "./config";
+
+export const obtenerAnalistasPerformance = async () => {
+  const res = await api.get("/bi-analistas/");
+  return res.data;
+};

--- a/src/pages/InformesAnalistas.jsx
+++ b/src/pages/InformesAnalistas.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { obtenerAnalistasPerformance } from "../api/analistas";
+
+const InformesAnalistas = () => {
+  const [analistas, setAnalistas] = useState([]);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const data = await obtenerAnalistasPerformance();
+        setAnalistas(data);
+      } catch (err) {
+        console.error("Error al cargar analistas", err);
+      }
+    };
+    cargar();
+  }, []);
+
+  return (
+    <div className="text-white">
+      <h1 className="text-3xl font-bold mb-6">Informes de Analistas</h1>
+      <div className="bg-gray-800 p-6 rounded-lg">
+        <table className="w-full text-left">
+          <thead>
+            <tr className="border-b border-gray-700">
+              <th className="p-2">Analista</th>
+              <th className="p-2">Clientes asignados</th>
+              <th className="p-2">Cierres Contabilidad</th>
+              <th className="p-2">Cierres Nómina</th>
+            </tr>
+          </thead>
+          <tbody>
+            {analistas.map((a) => (
+              <tr key={a.id} className="border-b border-gray-700">
+                <td className="p-2">{a.nombre} {a.apellido}</td>
+                <td className="p-2 text-center">{a.clientes_asignados}</td>
+                <td className="p-2 text-center">{a.cierres_contabilidad}</td>
+                <td className="p-2 text-center">{a.cierres_nomina}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default InformesAnalistas;


### PR DESCRIPTION
## Summary
- add performance serializer for analysts
- expose analytic performance in API
- create analyst performance viewset route
- fetch analyst performance in frontend
- add InformesAnalistas page and routing

## Testing
- `pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a0947998083239d6be53faf41a338