### PR TITLE
Fetch incidence categories dynamically

### DIFF
--- a/src/api/nomina.js
+++ b/src/api/nomina.js
@@ -232,3 +232,8 @@ export const obtenerConceptosRemuneracionNovedades = async (clienteId) => {
   const response = await api.get(`/nomina/conceptos-remuneracion-novedades/?cliente=${clienteId}`);
   return response.data;
 };
+
+export const obtenerCategoriasIncidencias = async () => {
+  const response = await api.get('/nomina/incidencias/categorias/');
+  return response.data;
+};

--- a/src/components/TarjetasCierreNomina/IncidenciasEncontradasSection.jsx
+++ b/src/components/TarjetasCierreNomina/IncidenciasEncontradasSection.jsx
@@ -1,19 +1,26 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { AlertOctagon, ChevronDown, ChevronRight } from "lucide-react";
 import IncidenciaCard from "./IncidenciasEncontradas/IncidenciaCard";
+import { obtenerCategoriasIncidencias } from "../../api/nomina";
 
 const IncidenciasEncontradasSection = () => {
   const [expandido, setExpandido] = useState(true);
+  const [categorias, setCategorias] = useState([]);
 
-  const categorias = [
-    {
-      id: "info-faltante",
-      titulo: "Información Faltante",
-      descripcion:
-        "Comparar la información del archivo Movimientos con los datos de Finiquitos, Incidencias/Ausentismos e Ingresos.",
-      items: [],
-    },
-  ];
+  useEffect(() => {
+    const cargarCategorias = async () => {
+      try {
+        const data = await obtenerCategoriasIncidencias();
+        if (Array.isArray(data)) {
+          setCategorias(data);
+        }
+      } catch (error) {
+        console.error("Error obteniendo categorías de incidencias:", error);
+      }
+    };
+
+    cargarCategorias();
+  }, []);
 
   return (
     <section className="space-y-6">


### PR DESCRIPTION
## Summary
- add API call to retrieve incidence categories
- fetch categories on mount in IncidenciasEncontradasSection
- render fetched categories using IncidenciaCard

## Testing
- `backend/venv/bin/python backend/manage.py test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684a196d10308323974508f0e2a4127c