### PR TITLE
Remove Historial buttons from contabilidad cards

### DIFF
--- a/src/components/TarjetasCierreContabilidad/ClasificacionBulkCard.jsx
+++ b/src/components/TarjetasCierreContabilidad/ClasificacionBulkCard.jsx
@@ -1,8 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import EstadoBadge from '../EstadoBadge';
 import ModalClasificacionRegistrosRaw from '../ModalClasificacionRegistrosRaw';
-import HistorialCambios from '../HistorialCambios';
-import { Download, FileText, Trash2, RefreshCw, History, Settings, Database } from 'lucide-react';
+import { Download, FileText, Trash2, RefreshCw, Settings, Database } from 'lucide-react';
 import { 
   subirClasificacionBulk, 
   obtenerBulkClasificaciones, 
@@ -20,7 +19,6 @@ const ClasificacionBulkCard = ({ clienteId, onCompletado, disabled }) => {
   const [uploads, setUploads] = useState([]);
   const [error, setError] = useState("");
   const [ultimoUpload, setUltimoUpload] = useState(null);
-  const [historialAbierto, setHistorialAbierto] = useState(false);
   const [eliminando, setEliminando] = useState(false);
   const [errorEliminando, setErrorEliminando] = useState("");
   const [registrosRaw, setRegistrosRaw] = useState([]);
@@ -183,13 +181,6 @@ const ClasificacionBulkCard = ({ clienteId, onCompletado, disabled }) => {
           <Settings size={16} />
           Ver clasificaciones
         </button>
-        <button
-          onClick={() => setHistorialAbierto(true)}
-          className="px-3 py-1 rounded text-sm font-medium transition bg-gray-700 hover:bg-gray-600 text-white flex items-center gap-2"
-        >
-          <History size={16} />
-          Historial
-        </button>
       </div>
       
       {/* Información del estado y resumen */}
@@ -241,13 +232,6 @@ const ClasificacionBulkCard = ({ clienteId, onCompletado, disabled }) => {
         }}
       />
 
-      {/* Historial de cambios */}
-      <HistorialCambios
-        tipoUpload="clasificacion"
-        clienteId={clienteId}
-        abierto={historialAbierto}
-        onClose={() => setHistorialAbierto(false)}
-      />
     </div>
   );
 };

--- a/src/components/TarjetasCierreContabilidad/TipoDocumentoCard.jsx
+++ b/src/components/TarjetasCierreContabilidad/TipoDocumentoCard.jsx
@@ -1,8 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 import ModalTipoDocumentoCRUD from "./ModalTipoDocumentoCRUD";
-import HistorialCambios from "../HistorialCambios";
 import Notificacion from "../Notificacion";
-import { Download, History } from "lucide-react";
+import { Download } from "lucide-react";
 import EstadoBadge from "../EstadoBadge";
 import { 
   descargarPlantillaTipoDocumento, 
@@ -19,7 +18,6 @@ const TipoDocumentoCard = ({ clienteId, onCompletado, disabled }) => {
   const [subiendo, setSubiendo] = useState(false);
   const [error, setError] = useState("");
   const [modalAbierto, setModalAbierto] = useState(false);
-  const [historialAbierto, setHistorialAbierto] = useState(false);
   const [tiposDocumento, setTiposDocumento] = useState([]);
   const [eliminando, setEliminando] = useState(false);
   const [errorEliminando, setErrorEliminando] = useState("");
@@ -225,13 +223,6 @@ const TipoDocumentoCard = ({ clienteId, onCompletado, disabled }) => {
                     >
                         Ver tipos de documento
                     </button>
-                    <button
-                        onClick={() => setHistorialAbierto(true)}
-                        className="px-3 py-1 rounded text-sm font-medium transition bg-gray-700 hover:bg-gray-600 text-white flex items-center gap-2"
-                    >
-                        <History size={16} />
-                        Historial
-                    </button>
                 </div>
                 <ModalTipoDocumentoCRUD
                     abierto={modalAbierto}
@@ -243,14 +234,6 @@ const TipoDocumentoCard = ({ clienteId, onCompletado, disabled }) => {
                     eliminando={eliminando}
                     errorEliminando={errorEliminando}
                     onNotificacion={mostrarNotificacion}
-                />
-
-                {/* Historial de cambios */}
-                <HistorialCambios
-                    tipoUpload="tipo_documento"
-                    clienteId={clienteId}
-                    abierto={historialAbierto}
-                    onClose={() => setHistorialAbierto(false)}
                 />
 
                 <span className="text-xs text-gray-400 italic mt-2">


### PR DESCRIPTION
## Summary
- remove Historial modal/logic from TipoDocumentoCard
- remove Historial modal/logic from ClasificacionBulkCard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684fa15afb9c8323904969dc472f09b4