### PR TITLE
Dynamic step numbers for cierre cards

### DIFF
--- a/src/components/TarjetasCierreContabilidad/CierreProgreso.jsx
+++ b/src/components/TarjetasCierreContabilidad/CierreProgreso.jsx
@@ -69,6 +69,8 @@ const CierreProgreso = ({ cierre, cliente }) => {
   const handleTraduccionCompletada = () => setNombresInglesReady(true);
   const handleLibroMayorCompletado = () => setLibroMayorReady(true);
 
+  let paso = 1;
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
       {/* Paso 1: Tipos de Documento */}
@@ -76,6 +78,7 @@ const CierreProgreso = ({ cierre, cliente }) => {
         clienteId={cliente.id}
         onCompletado={handleTipoDocumentoCompletado}
         disabled={false}
+        numeroPaso={paso++}
       />
       
       {/* Paso 2: Clasificación de Cuentas */}
@@ -83,6 +86,7 @@ const CierreProgreso = ({ cierre, cliente }) => {
         clienteId={cliente.id}
         onCompletado={handleClasificacionCompletado}
         disabled={!tipoDocumentoReady}
+        numeroPaso={paso++}
       />
       
       {/* Paso 3: Nombres en Inglés (solo si cliente es bilingüe) */}
@@ -93,6 +97,7 @@ const CierreProgreso = ({ cierre, cliente }) => {
           clasificacionReady={clasificacionReady}
           onCompletado={handleTraduccionCompletada}
           disabled={!clasificacionReady}
+          numeroPaso={paso++}
         />
       )}
       
@@ -104,6 +109,7 @@ const CierreProgreso = ({ cierre, cliente }) => {
         tipoDocumentoReady={tipoDocumentoReady}
         clasificacionReady={clasificacionReady}
         nombresInglesReady={nombresInglesReady}
+        numeroPaso={paso++}
       />
     </div>
   );

--- a/src/components/TarjetasCierreContabilidad/ClasificacionBulkCard.jsx
+++ b/src/components/TarjetasCierreContabilidad/ClasificacionBulkCard.jsx
@@ -12,7 +12,7 @@ import {
   obtenerClasificacionesArchivo
 } from '../../api/contabilidad';
 
-const ClasificacionBulkCard = ({ clienteId, onCompletado, disabled }) => {
+const ClasificacionBulkCard = ({ clienteId, onCompletado, disabled, numeroPaso }) => {
   const [archivo, setArchivo] = useState(null);
   const [estado, setEstado] = useState('pendiente');
   const [subiendo, setSubiendo] = useState(false);
@@ -125,8 +125,8 @@ const ClasificacionBulkCard = ({ clienteId, onCompletado, disabled }) => {
   };
 
   return (
-    <div className={`bg-gray-800 p-4 rounded-xl shadow-lg flex flex-col gap-3 ${disabled ? 'opacity-60 pointer-events-none' : ''}`}>        
-      <h3 className="text-lg font-semibold mb-3">2. Subir Clasificaciones de Cuentas</h3>
+    <div className={`bg-gray-800 p-4 rounded-xl shadow-lg flex flex-col gap-3 ${disabled ? 'opacity-60 pointer-events-none' : ''}`}>
+      <h3 className="text-lg font-semibold mb-3">{numeroPaso}. Subir Clasificaciones de Cuentas</h3>
       <div className="flex items-center gap-2 mb-2">
         <span className="font-semibold">Estado:</span>
         <EstadoBadge estado={estado === 'completado' ? 'subido' : estado} />

--- a/src/components/TarjetasCierreContabilidad/LibroMayorCard.jsx
+++ b/src/components/TarjetasCierreContabilidad/LibroMayorCard.jsx
@@ -2,13 +2,14 @@ import { useEffect, useState, useRef } from "react";
 import { obtenerLibrosMayor, subirLibroMayor } from "../../api/contabilidad";
 import EstadoBadge from "../EstadoBadge";
 
-const LibroMayorCard = ({ 
-  cierreId, 
-  disabled, 
-  onCompletado, 
-  tipoDocumentoReady, 
-  clasificacionReady, 
-  nombresInglesReady 
+const LibroMayorCard = ({
+  cierreId,
+  disabled,
+  onCompletado,
+  tipoDocumentoReady,
+  clasificacionReady,
+  nombresInglesReady,
+  numeroPaso
 }) => {
   const [libroActual, setLibroActual] = useState(null);
   const [archivoNombre, setArchivoNombre] = useState("");
@@ -97,7 +98,7 @@ const LibroMayorCard = ({
 
   return (
     <div className={`bg-gray-800 p-4 rounded-xl shadow-lg flex flex-col gap-3 ${disabled ? "opacity-60 pointer-events-none" : ""}`}>
-      <h3 className="text-lg font-semibold mb-3">4. Libro Mayor y Procesamiento</h3>
+      <h3 className="text-lg font-semibold mb-3">{numeroPaso}. Libro Mayor y Procesamiento</h3>
 
       {/* Información de prerequisitos */}
       <div className="text-xs text-gray-400 mb-2">

--- a/src/components/TarjetasCierreContabilidad/NombresEnInglesCard.jsx
+++ b/src/components/TarjetasCierreContabilidad/NombresEnInglesCard.jsx
@@ -17,7 +17,8 @@ const NombresEnInglesCard = ({
   clienteId,
   clasificacionReady,
   onCompletado,
-  disabled
+  disabled,
+  numeroPaso
 }) => {
   const [estado, setEstado] = useState("pendiente");
   const [archivo, setArchivo] = useState(null);
@@ -183,7 +184,7 @@ const NombresEnInglesCard = ({
   // Render
   return (
     <div className={`bg-gray-800 p-4 rounded-xl shadow-lg flex flex-col gap-3 ${!clasificacionReady || disabled ? "opacity-60 pointer-events-none" : ""}`}>
-      <h3 className="text-lg font-semibold mb-3">3. Nombres en inglés de cuentas</h3>
+      <h3 className="text-lg font-semibold mb-3">{numeroPaso}. Nombres en inglés de cuentas</h3>
 
       {/* Estado global y progreso */}
       <div className="flex flex-col gap-1 mb-2">

--- a/src/components/TarjetasCierreContabilidad/TipoDocumentoCard.jsx
+++ b/src/components/TarjetasCierreContabilidad/TipoDocumentoCard.jsx
@@ -12,7 +12,7 @@ import {
   eliminarTodosTiposDocumento 
 } from "../../api/contabilidad";
 
-const TipoDocumentoCard = ({ clienteId, onCompletado, disabled }) => {
+const TipoDocumentoCard = ({ clienteId, onCompletado, disabled, numeroPaso }) => {
   const [estado, setEstado] = useState("pendiente");
   const [archivoNombre, setArchivoNombre] = useState("");
   const [subiendo, setSubiendo] = useState(false);
@@ -163,7 +163,7 @@ const TipoDocumentoCard = ({ clienteId, onCompletado, disabled }) => {
 
   return (
     <div className={`bg-gray-800 p-4 rounded-xl shadow-lg flex flex-col gap-3 ${disabled ? "opacity-60 pointer-events-none" : ""}`}>
-        <h3 className="text-lg font-semibold mb-3">1. Tipo de Documento</h3>
+        <h3 className="text-lg font-semibold mb-3">{numeroPaso}. Tipo de Documento</h3>
             <div className="flex items-center gap-2 mb-2">
                 <span className="font-semibold">Estado:</span>
                 <EstadoBadge estado={estado === "subido" ? "subido" : "pendiente"} />


### PR DESCRIPTION
## Summary
- pass a new `numeroPaso` prop to closing task cards
- compute step numbers sequentially in `CierreProgreso`

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684fa6102fa88323a47abc6b9a593d3a