### PR TITLE
Add example contabilidad data loader

### DIFF
--- a/streamlit_conta/data/__init__.py
+++ b/streamlit_conta/data/__init__.py
@@ -1,1 +1,2 @@
 # Data package for SGM Contabilidad Dashboard
+from .loader_contabilidad import cargar_datos as cargar_datos_ejemplo

--- a/streamlit_conta/data/contabilidad_ejemplo.json
+++ b/streamlit_conta/data/contabilidad_ejemplo.json
@@ -1,0 +1,161 @@
+{
+  "cliente": "Empresa de Ejemplo S.A.",
+  "clasificaciones": [
+    {
+      "id": 1,
+      "nombre": "IFRS",
+      "descripcion": "Clasificación según estándares IFRS",
+      "idioma": "en",
+      "opciones": [
+        {"valor": "IFRS_001", "descripcion": "Current Assets"},
+        {"valor": "IFRS_002", "descripcion": "Non-Current Assets"},
+        {"valor": "IFRS_003", "descripcion": "Current Liabilities"},
+        {"valor": "IFRS_004", "descripcion": "Non-Current Liabilities"},
+        {"valor": "IFRS_005", "descripcion": "Equity"},
+        {"valor": "IFRS_006", "descripcion": "Revenue"},
+        {"valor": "IFRS_007", "descripcion": "Expenses"}
+      ]
+    },
+    {
+      "id": 2,
+      "nombre": "Naturaleza",
+      "descripcion": "Clasificación por naturaleza de la cuenta",
+      "idioma": "es",
+      "opciones": [
+        {"valor": "NAT_001", "descripcion": "Operacional"},
+        {"valor": "NAT_002", "descripcion": "Financiero"},
+        {"valor": "NAT_003", "descripcion": "Extraordinario"},
+        {"valor": "NAT_004", "descripcion": "Fiscal"}
+      ]
+    },
+    {
+      "id": 3,
+      "nombre": "Segmento",
+      "descripcion": "Clasificación por segmento de negocio",
+      "idioma": "es",
+      "opciones": [
+        {"valor": "SEG_001", "descripcion": "Retail"},
+        {"valor": "SEG_002", "descripcion": "Corporativo"},
+        {"valor": "SEG_003", "descripcion": "Internacional"},
+        {"valor": "SEG_004", "descripcion": "Digital"}
+      ]
+    }
+  ],
+  "centros_costo": [
+    {"codigo": "CC001", "nombre": "Administración General"},
+    {"codigo": "CC002", "nombre": "Ventas"},
+    {"codigo": "CC003", "nombre": "Producción"}
+  ],
+  "tipos_documento": [
+    {"codigo": "FAC", "descripcion": "Factura"},
+    {"codigo": "BOL", "descripcion": "Boleta"},
+    {"codigo": "CHE", "descripcion": "Cheque"},
+    {"codigo": "DEP", "descripcion": "Depósito"},
+    {"codigo": "AJU", "descripcion": "Ajuste"}
+  ],
+  "cierres": [
+    {
+      "id": 1,
+      "cliente": "Empresa de Ejemplo S.A.",
+      "periodo": "2024-12",
+      "estado": "completo",
+      "fecha_inicio_libro": "2024-12-01",
+      "fecha_fin_libro": "2024-12-31",
+      "cuentas_nuevas": 2,
+      "parsing_completado": true,
+      "plan_cuentas": [
+        {"codigo": "1101", "nombre": "Caja", "nombre_en": "Cash", "tipo": "activo_corriente"},
+        {"codigo": "2101", "nombre": "Cuentas por Pagar", "nombre_en": "Payables", "tipo": "pasivo_corriente"},
+        {"codigo": "3101", "nombre": "Capital", "nombre_en": "Capital", "tipo": "patrimonio"},
+        {"codigo": "4101", "nombre": "Ventas", "nombre_en": "Sales", "tipo": "ingreso"},
+        {"codigo": "5101", "nombre": "Costos de Ventas", "nombre_en": "Cost of Sales", "tipo": "costo"},
+        {"codigo": "5201", "nombre": "Gastos Administración", "nombre_en": "Admin Expenses", "tipo": "gasto"}
+      ],
+      "movimientos": [
+        {
+          "id": 1,
+          "fecha": "2024-12-01",
+          "numero_comprobante": "COMP-000001",
+          "descripcion": "Venta factura #1001",
+          "tipo": "Venta",
+          "cuenta_codigo": "4101",
+          "debe": 0,
+          "haber": 500000,
+          "tipo_documento": "FAC",
+          "numero_documento": "F-1001",
+          "centro_costo": "CC001"
+        },
+        {
+          "id": 2,
+          "fecha": "2024-12-02",
+          "numero_comprobante": "COMP-000002",
+          "descripcion": "Compra mercadería #2001",
+          "tipo": "Compra",
+          "cuenta_codigo": "5101",
+          "debe": 300000,
+          "haber": 0,
+          "tipo_documento": "FAC",
+          "numero_documento": "FC-2001",
+          "centro_costo": "CC002"
+        },
+        {
+          "id": 3,
+          "fecha": "2024-12-03",
+          "numero_comprobante": "COMP-000003",
+          "descripcion": "Pago a proveedor",
+          "tipo": "Pago",
+          "cuenta_codigo": "1101",
+          "debe": 0,
+          "haber": 200000,
+          "tipo_documento": "CHE",
+          "numero_documento": "CH-3001",
+          "centro_costo": "CC001"
+        },
+        {
+          "id": 4,
+          "fecha": "2024-12-04",
+          "numero_comprobante": "COMP-000004",
+          "descripcion": "Cobranza cliente",
+          "tipo": "Cobranza",
+          "cuenta_codigo": "1101",
+          "debe": 500000,
+          "haber": 0,
+          "tipo_documento": "DEP",
+          "numero_documento": "D-4001",
+          "centro_costo": "CC001"
+        },
+        {
+          "id": 5,
+          "fecha": "2024-12-05",
+          "numero_comprobante": "COMP-000005",
+          "descripcion": "Gasto operacional",
+          "tipo": "Gasto",
+          "cuenta_codigo": "5201",
+          "debe": 100000,
+          "haber": 0,
+          "tipo_documento": "BOL",
+          "numero_documento": "B-5001",
+          "centro_costo": "CC003"
+        }
+      ],
+      "resumen_financiero": {
+        "activo_corriente": {"debe": 500000, "haber": 200000, "saldo": 300000, "num_movimientos": 2},
+        "activo_no_corriente": {"debe": 0, "haber": 0, "saldo": 0, "num_movimientos": 0},
+        "pasivo_corriente": {"debe": 0, "haber": 0, "saldo": 0, "num_movimientos": 0},
+        "pasivo_no_corriente": {"debe": 0, "haber": 0, "saldo": 0, "num_movimientos": 0},
+        "patrimonio": {"debe": 0, "haber": 0, "saldo": 0, "num_movimientos": 0},
+        "ingreso": {"debe": 0, "haber": 500000, "saldo": 500000, "num_movimientos": 1},
+        "costo": {"debe": 300000, "haber": 0, "saldo": 300000, "num_movimientos": 1},
+        "gasto": {"debe": 100000, "haber": 0, "saldo": 100000, "num_movimientos": 1},
+        "totales": {
+          "total_activos": 300000,
+          "total_pasivos": 0,
+          "total_patrimonio": 0,
+          "total_ingresos": 500000,
+          "total_costos_gastos": 400000,
+          "resultado_ejercicio": 100000
+        }
+      }
+    }
+  ]
+}

--- a/streamlit_conta/data/loader_contabilidad.py
+++ b/streamlit_conta/data/loader_contabilidad.py
@@ -1,0 +1,23 @@
+import json
+import pathlib
+
+
+def cargar_datos():
+    base = pathlib.Path(__file__).parent
+    with open(base / "contabilidad_ejemplo.json", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    cierre_actual = raw.get("cierres", [{}])[0]
+    return {
+        "cliente": raw.get("cliente"),
+        "clasificaciones": raw.get("clasificaciones", []),
+        "centros_costo": raw.get("centros_costo", []),
+        "tipos_documento": raw.get("tipos_documento", []),
+        "cierre": {k: cierre_actual.get(k) for k in [
+            "id", "periodo", "estado",
+            "fecha_inicio_libro", "fecha_fin_libro",
+            "cuentas_nuevas", "parsing_completado"]},
+        "plan_cuentas": cierre_actual.get("plan_cuentas", []),
+        "movimientos": cierre_actual.get("movimientos", []),
+        "resumen_financiero": cierre_actual.get("resumen_financiero", {})
+    }


### PR DESCRIPTION
## Summary
- add example accounting dataset for Streamlit demo
- provide `loader_contabilidad.py` helper to load the JSON sample
- expose the loader via the data package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6852ed951d4c8323b48d289710f1c4bb