### PR TITLE
Add sample payroll dashboard

### DIFF
--- a/streamlit_nomina/app.py
+++ b/streamlit_nomina/app.py
@@ -1,3 +1,14 @@
 import streamlit as st
-st.title("Dashboard de Nomina")
-st.write("Hola mundo desde Streamlit.")
+from layout.sidebar import mostrar_sidebar
+from layout.header import mostrar_header
+from data.loader import cargar_datos
+from views import dashboard_general
+
+st.set_page_config(layout="wide", page_title="SGM - Dashboard Nómina", page_icon="💼")
+
+data = cargar_datos()
+selected_tab = mostrar_sidebar()
+mostrar_header()
+
+if selected_tab == "📊 Dashboard General":
+    dashboard_general.mostrar(data)

--- a/streamlit_nomina/components/__init__.py
+++ b/streamlit_nomina/components/__init__.py
@@ -1,0 +1,1 @@
+# Components package for SGM Nomina Dashboard

--- a/streamlit_nomina/data/__init__.py
+++ b/streamlit_nomina/data/__init__.py
@@ -1,0 +1,1 @@
+# Data package for SGM Nomina Dashboard

--- a/streamlit_nomina/data/loader.py
+++ b/streamlit_nomina/data/loader.py
@@ -1,0 +1,11 @@
+import json
+import pathlib
+
+
+def cargar_datos():
+    """Carga datos de nómina desde un archivo JSON de ejemplo"""
+    current_dir = pathlib.Path(__file__).parent.resolve()
+    json_file_path = current_dir / "payroll_example.json"
+    with open(json_file_path, "r", encoding="utf-8") as file:
+        data = json.load(file)
+    return data

--- a/streamlit_nomina/data/payroll_example.json
+++ b/streamlit_nomina/data/payroll_example.json
@@ -1,0 +1,27 @@
+{
+  "cierre": {
+    "cliente": "Compañía XYZ",
+    "periodo": "2024-12",
+    "estado": "completado",
+    "num_empleados": 5,
+    "total_haberes": 5600000,
+    "total_descuentos": 1200000
+  },
+  "empleados": [
+    {"rut": "11111111-1", "nombre": "Ana", "cargo": "Analista", "sueldo_base": 1200000, "haberes": 1400000, "descuentos": 200000},
+    {"rut": "22222222-2", "nombre": "Luis", "cargo": "Jefe", "sueldo_base": 1800000, "haberes": 2200000, "descuentos": 400000},
+    {"rut": "33333333-3", "nombre": "Pedro", "cargo": "Técnico", "sueldo_base": 900000, "haberes": 1000000, "descuentos": 150000},
+    {"rut": "44444444-4", "nombre": "Sofía", "cargo": "Asistente", "sueldo_base": 800000, "haberes": 900000, "descuentos": 120000},
+    {"rut": "55555555-5", "nombre": "Carla", "cargo": "Gerente", "sueldo_base": 2200000, "haberes": 2500000, "descuentos": 330000}
+  ],
+  "resumen_haberes": [
+    {"concepto": "Sueldo Base", "total": 6900000},
+    {"concepto": "Horas Extra", "total": 300000},
+    {"concepto": "Bonos", "total": 400000}
+  ],
+  "resumen_descuentos": [
+    {"concepto": "AFP", "total": 600000},
+    {"concepto": "Salud", "total": 400000},
+    {"concepto": "Impuesto", "total": 200000}
+  ]
+}

--- a/streamlit_nomina/layout/__init__.py
+++ b/streamlit_nomina/layout/__init__.py
@@ -1,0 +1,1 @@
+# Layout package for SGM Nomina Dashboard

--- a/streamlit_nomina/layout/header.py
+++ b/streamlit_nomina/layout/header.py
@@ -1,0 +1,8 @@
+import streamlit as st
+import getpass
+
+
+def mostrar_header():
+    st.title("💼 Dashboard de Nómina")
+    st.caption(f"👤 Usuario: {getpass.getuser()} | 🏢 Cliente: Compañía XYZ | 📅 Período: 2024")
+    st.markdown("---")

--- a/streamlit_nomina/layout/sidebar.py
+++ b/streamlit_nomina/layout/sidebar.py
@@ -1,0 +1,15 @@
+import streamlit as st
+
+
+def mostrar_sidebar():
+    st.sidebar.markdown("## **Dashboard de Nómina**")
+    selected_tab = st.sidebar.radio(
+        "Selecciona un reporte:",
+        ["📊 Dashboard General"],
+        index=0
+    )
+    st.sidebar.markdown("---")
+    st.sidebar.markdown("💼 *Análisis de remuneraciones*")
+    st.sidebar.markdown("👤 **Cliente:** Compañía XYZ")
+    st.sidebar.markdown("📅 **Período:** 2024")
+    return selected_tab

--- a/streamlit_nomina/requirements.txt
+++ b/streamlit_nomina/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.28.0
+pandas>=2.0.0
+plotly>=5.15.0
+numpy>=1.24.0
+openpyxl>=3.1.0

--- a/streamlit_nomina/utils/__init__.py
+++ b/streamlit_nomina/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utils package for SGM Nomina Dashboard

--- a/streamlit_nomina/views/__init__.py
+++ b/streamlit_nomina/views/__init__.py
@@ -1,0 +1,1 @@
+# Views package for SGM Nomina Dashboard

--- a/streamlit_nomina/views/dashboard_general.py
+++ b/streamlit_nomina/views/dashboard_general.py
@@ -1,0 +1,77 @@
+import streamlit as st
+import pandas as pd
+import plotly.express as px
+
+
+def mostrar(data=None):
+    st.header("📊 Resumen General de Nómina")
+    st.markdown("**Visión general del cierre de remuneraciones**")
+
+    if not data:
+        st.error("No hay datos disponibles")
+        return
+
+    mostrar_info_cierre(data)
+    mostrar_kpis(data)
+    mostrar_resumen_conceptos(data)
+    mostrar_empleados(data)
+
+
+def mostrar_info_cierre(data):
+    cierre = data.get("cierre", {})
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        st.metric("Cliente", cierre.get("cliente", "-"))
+    with col2:
+        st.metric("Período", cierre.get("periodo", "-"))
+    with col3:
+        st.metric("Estado", cierre.get("estado", "-").title())
+
+
+def mostrar_kpis(data):
+    cierre = data.get("cierre", {})
+    haberes = cierre.get("total_haberes", 0)
+    descuentos = cierre.get("total_descuentos", 0)
+    liquido = haberes - descuentos
+
+    col1, col2, col3, col4 = st.columns(4)
+    with col1:
+        st.metric("Empleados", cierre.get("num_empleados", 0))
+    with col2:
+        st.metric("Total Haberes", f"${haberes:,.0f}")
+    with col3:
+        st.metric("Total Descuentos", f"${descuentos:,.0f}")
+    with col4:
+        st.metric("Total Líquido", f"${liquido:,.0f}")
+
+
+def mostrar_resumen_conceptos(data):
+    col1, col2 = st.columns(2)
+    resumen_haberes = pd.DataFrame(data.get("resumen_haberes", []))
+    resumen_desc = pd.DataFrame(data.get("resumen_descuentos", []))
+
+    with col1:
+        st.subheader("Haberes")
+        if not resumen_haberes.empty:
+            fig = px.bar(resumen_haberes, x="concepto", y="total", title="Distribución de Haberes")
+            st.plotly_chart(fig, use_container_width=True)
+        else:
+            st.info("Sin datos de haberes")
+
+    with col2:
+        st.subheader("Descuentos")
+        if not resumen_desc.empty:
+            fig = px.bar(resumen_desc, x="concepto", y="total", title="Distribución de Descuentos", color_discrete_sequence=["#ef553b"])
+            st.plotly_chart(fig, use_container_width=True)
+        else:
+            st.info("Sin datos de descuentos")
+
+
+def mostrar_empleados(data):
+    st.markdown("---")
+    st.subheader("Empleados")
+    df_emp = pd.DataFrame(data.get("empleados", []))
+    if df_emp.empty:
+        st.info("Sin información de empleados")
+    else:
+        st.dataframe(df_emp)


### PR DESCRIPTION
## Summary
- build simple Streamlit dashboard for payroll
- load example payroll data from JSON
- create header and sidebar layout for the new app
- show KPIs and charts in the dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685324fee2d4832392d7e8f11b84809a