### PR TITLE
Add ActivityLogMixin and refactor viewsets

### DIFF
--- a/backend/contabilidad/mixins.py
+++ b/backend/contabilidad/mixins.py
@@ -1,0 +1,41 @@
+from .utils.activity_logger import registrar_actividad_tarjeta
+
+
+class ActivityLogMixin:
+    """Mixin para registrar acciones de creación, actualización y eliminación."""
+
+    def _log_action(
+        self,
+        *,
+        cliente_id,
+        periodo,
+        tarjeta,
+        accion,
+        descripcion,
+        detalles=None,
+        resultado="exito",
+    ):
+        """Llama a ``registrar_actividad_tarjeta`` usando la request actual."""
+        return registrar_actividad_tarjeta(
+            cliente_id=cliente_id,
+            periodo=periodo,
+            tarjeta=tarjeta,
+            accion=accion,
+            descripcion=descripcion,
+            usuario=getattr(self.request, "user", None),
+            detalles=detalles,
+            resultado=resultado,
+            ip_address=self.request.META.get("REMOTE_ADDR") if hasattr(self, "request") else None,
+        )
+
+    def log_create(self, **kwargs):
+        kwargs.setdefault("accion", "manual_create")
+        return self._log_action(**kwargs)
+
+    def log_update(self, **kwargs):
+        kwargs.setdefault("accion", "manual_edit")
+        return self._log_action(**kwargs)
+
+    def log_delete(self, **kwargs):
+        kwargs.setdefault("accion", "manual_delete")
+        return self._log_action(**kwargs)

--- a/backend/contabilidad/views.py
+++ b/backend/contabilidad/views.py
@@ -30,6 +30,7 @@ from rest_framework.views import APIView
 from .utils.activity_logger import (
     registrar_actividad_tarjeta,
 )  # Comentado temporalmente
+from .mixins import ActivityLogMixin
 
 logger = logging.getLogger(__name__)
 
@@ -1592,7 +1593,7 @@ def eliminar_nombres_ingles(request, cliente_id):
         return Response({"error": f"Error al eliminar: {str(e)}"}, status=500)
 
 
-class TipoDocumentoViewSet(viewsets.ModelViewSet):
+class TipoDocumentoViewSet(ActivityLogMixin, viewsets.ModelViewSet):
     queryset = TipoDocumento.objects.all()
     serializer_class = TipoDocumentoSerializer
     permission_classes = [IsAuthenticated]
@@ -1622,20 +1623,16 @@ class TipoDocumentoViewSet(viewsets.ModelViewSet):
             periodo_actividad = obtener_periodo_actividad_para_cliente(cliente)
 
             # Registrar creación manual
-            registrar_actividad_tarjeta(
+            self.log_create(
                 cliente_id=cliente_id,
                 periodo=periodo_actividad,
                 tarjeta="tipo_documento",
-                accion="manual_create",
                 descripcion=f"Creado tipo documento: {instance.codigo} - {instance.descripcion}",
-                usuario=self.request.user,
                 detalles={
                     "codigo": instance.codigo,
                     "descripcion": instance.descripcion,
                     "id": instance.id,
                 },
-                resultado="exito",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
         except Cliente.DoesNotExist:
@@ -1653,16 +1650,13 @@ class TipoDocumentoViewSet(viewsets.ModelViewSet):
                 pass
             
             # Registrar error
-            registrar_actividad_tarjeta(
+            self.log_create(
                 cliente_id=cliente_id,
                 periodo=periodo_actividad,
                 tarjeta="tipo_documento",
-                accion="manual_create",
                 descripcion=f"Error al crear tipo documento: {str(e)}",
-                usuario=self.request.user,
                 detalles={"error": str(e), "data": self.request.data},
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
             raise
 
@@ -1682,13 +1676,11 @@ class TipoDocumentoViewSet(viewsets.ModelViewSet):
             periodo_actividad = obtener_periodo_actividad_para_cliente(cliente)
 
             # Registrar edición
-            registrar_actividad_tarjeta(
+            self.log_update(
                 cliente_id=cliente_id,
                 periodo=periodo_actividad,
                 tarjeta="tipo_documento",
-                accion="manual_edit",
                 descripcion=f"Editado tipo documento ID:{instance.id}: {old_instance.codigo} → {instance.codigo}",
-                usuario=self.request.user,
                 detalles={
                     "id": instance.id,
                     "cambios": {
@@ -1702,8 +1694,6 @@ class TipoDocumentoViewSet(viewsets.ModelViewSet):
                         },
                     },
                 },
-                resultado="exito",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
         except Exception as e:
@@ -1711,20 +1701,17 @@ class TipoDocumentoViewSet(viewsets.ModelViewSet):
             periodo_actividad = obtener_periodo_actividad_para_cliente(cliente)
             
             # Registrar error
-            registrar_actividad_tarjeta(
+            self.log_update(
                 cliente_id=cliente_id,
                 periodo=periodo_actividad,
                 tarjeta="tipo_documento",
-                accion="manual_edit",
                 descripcion=f"Error al editar tipo documento ID:{old_instance.id}: {str(e)}",
-                usuario=self.request.user,
                 detalles={
                     "error": str(e),
                     "id": old_instance.id,
                     "data": self.request.data,
                 },
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
             raise
 
@@ -1744,16 +1731,12 @@ class TipoDocumentoViewSet(viewsets.ModelViewSet):
             periodo_actividad = obtener_periodo_actividad_para_cliente(cliente)
 
             # Registrar eliminación
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=cliente_id,
                 periodo=periodo_actividad,
                 tarjeta="tipo_documento",
-                accion="manual_delete",
                 descripcion=f'Eliminado tipo documento: {tipo_info["codigo"]} - {tipo_info["descripcion"]}',
-                usuario=self.request.user,
                 detalles=tipo_info,
-                resultado="exito",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
         except Exception as e:
@@ -1761,21 +1744,18 @@ class TipoDocumentoViewSet(viewsets.ModelViewSet):
             periodo_actividad = obtener_periodo_actividad_para_cliente(cliente)
             
             # Registrar error
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=cliente_id,
                 periodo=periodo_actividad,
                 tarjeta="tipo_documento",
-                accion="manual_delete",
                 descripcion=f'Error al eliminar tipo documento ID:{tipo_info["id"]}: {str(e)}',
-                usuario=self.request.user,
                 detalles={"error": str(e), **tipo_info},
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
             raise
 
 
-class NombreInglesViewSet(viewsets.ModelViewSet):
+class NombreInglesViewSet(ActivityLogMixin, viewsets.ModelViewSet):
     queryset = NombreIngles.objects.all()
     serializer_class = NombreInglesSerializer
     permission_classes = [IsAuthenticated]
@@ -1802,20 +1782,16 @@ class NombreInglesViewSet(viewsets.ModelViewSet):
             instance = serializer.save()
 
             # Registrar creación manual
-            registrar_actividad_tarjeta(
+            self.log_create(
                 cliente_id=cliente_id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="nombres_ingles",
-                accion="manual_create",
                 descripcion=f"Creado nombre inglés: {instance.cuenta_codigo} - {instance.nombre_ingles}",
-                usuario=self.request.user,
                 detalles={
                     "cuenta_codigo": instance.cuenta_codigo,
                     "nombre_ingles": instance.nombre_ingles,
                     "id": instance.id,
                 },
-                resultado="exito",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
         except Cliente.DoesNotExist:
@@ -1824,16 +1800,13 @@ class NombreInglesViewSet(viewsets.ModelViewSet):
             raise ValidationError("Cliente no encontrado")
         except Exception as e:
             # Registrar error
-            registrar_actividad_tarjeta(
+            self.log_create(
                 cliente_id=cliente_id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="nombres_ingles",
-                accion="manual_create",
                 descripcion=f"Error al crear nombre inglés: {str(e)}",
-                usuario=self.request.user,
                 detalles={"error": str(e), "data": self.request.data},
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
             raise
 
@@ -1849,13 +1822,11 @@ class NombreInglesViewSet(viewsets.ModelViewSet):
                 instance = serializer.save()
 
             # Registrar edición
-            registrar_actividad_tarjeta(
+            self.log_update(
                 cliente_id=cliente_id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="nombres_ingles",
-                accion="manual_edit",
                 descripcion=f"Editado nombre inglés ID:{instance.id}: {old_instance.cuenta_codigo} → {instance.cuenta_codigo}",
-                usuario=self.request.user,
                 detalles={
                     "id": instance.id,
                     "cambios": {
@@ -1869,26 +1840,21 @@ class NombreInglesViewSet(viewsets.ModelViewSet):
                         },
                     },
                 },
-                resultado="exito",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
         except Exception as e:
             # Registrar error
-            registrar_actividad_tarjeta(
+            self.log_update(
                 cliente_id=cliente_id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="nombres_ingles",
-                accion="manual_edit",
                 descripcion=f"Error al editar nombre inglés ID:{old_instance.id}: {str(e)}",
-                usuario=self.request.user,
                 detalles={
                     "error": str(e),
                     "id": old_instance.id,
                     "data": self.request.data,
                 },
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
             raise
 
@@ -1904,30 +1870,23 @@ class NombreInglesViewSet(viewsets.ModelViewSet):
             instance.delete()
 
             # Registrar eliminación
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=cliente_id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="nombres_ingles",
-                accion="manual_delete",
                 descripcion=f'Eliminado nombre inglés: {nombre_info["cuenta_codigo"]} - {nombre_info["nombre_ingles"]}',
-                usuario=self.request.user,
                 detalles=nombre_info,
-                resultado="exito",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
         except Exception as e:
             # Registrar error
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=cliente_id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="nombres_ingles",
-                accion="manual_delete",
                 descripcion=f'Error al eliminar nombre inglés ID:{nombre_info["id"]}: {str(e)}',
-                usuario=self.request.user,
                 detalles={"error": str(e), **nombre_info},
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
             raise
 
@@ -1960,7 +1919,7 @@ class MovimientoContableViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
 
 
-class ClasificacionSetViewSet(viewsets.ModelViewSet):
+class ClasificacionSetViewSet(ActivityLogMixin, viewsets.ModelViewSet):
     queryset = ClasificacionSet.objects.all()
     serializer_class = ClasificacionSetSerializer
     permission_classes = [IsAuthenticated]
@@ -1976,20 +1935,17 @@ class ClasificacionSetViewSet(viewsets.ModelViewSet):
         instance = serializer.save()
 
         # Registrar creación de set
-        registrar_actividad_tarjeta(
+        self.log_create(
             cliente_id=instance.cliente.id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="clasificacion",
             accion="set_create",
             descripcion=f"Creado set de clasificación: {instance.nombre}",
-            usuario=self.request.user,
             detalles={
                 "set_id": instance.id,
                 "set_nombre": instance.nombre,
                 "accion_origen": "manual_sets_tab",
             },
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
     def perform_update(self, serializer):
@@ -1997,21 +1953,18 @@ class ClasificacionSetViewSet(viewsets.ModelViewSet):
         instance = serializer.save()
 
         # Registrar edición de set
-        registrar_actividad_tarjeta(
+        self.log_update(
             cliente_id=instance.cliente.id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="clasificacion",
             accion="set_edit",
             descripcion=f"Editado set de clasificación: {old_instance.nombre} → {instance.nombre}",
-            usuario=self.request.user,
             detalles={
                 "set_id": instance.id,
                 "nombre_anterior": old_instance.nombre,
                 "nombre_nuevo": instance.nombre,
                 "accion_origen": "manual_sets_tab",
             },
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
     def perform_destroy(self, instance):
@@ -2030,43 +1983,38 @@ class ClasificacionSetViewSet(viewsets.ModelViewSet):
             super().perform_destroy(instance)
 
             # Registrar eliminación de set
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=set_info["cliente_id"],
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="clasificacion",
                 accion="set_delete",
                 descripcion=f'Eliminado set de clasificación: {set_info["nombre"]} (incluía {opciones_count} opciones)',
-                usuario=self.request.user,
                 detalles={
                     **set_info,
                     "opciones_eliminadas": opciones_count,
                     "accion_origen": "manual_sets_tab",
                 },
-                resultado="exito",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
         except Exception as e:
             # Registrar error
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=set_info["cliente_id"],
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="clasificacion",
                 accion="set_delete",
                 descripcion=f'Error al eliminar set de clasificación: {set_info["nombre"]} - {str(e)}',
-                usuario=self.request.user,
                 detalles={
                     **set_info,
                     "error": str(e),
                     "accion_origen": "manual_sets_tab",
                 },
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
             raise
 
 
-class ClasificacionOptionViewSet(viewsets.ModelViewSet):
+class ClasificacionOptionViewSet(ActivityLogMixin, viewsets.ModelViewSet):
     queryset = ClasificacionOption.objects.all()
     serializer_class = ClasificacionOptionSerializer
     permission_classes = [IsAuthenticated]
@@ -2082,13 +2030,12 @@ class ClasificacionOptionViewSet(viewsets.ModelViewSet):
         instance = serializer.save()
 
         # Registrar creación de opción
-        registrar_actividad_tarjeta(
+        self.log_create(
             cliente_id=instance.set_clas.cliente.id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="clasificacion",
             accion="option_create",
             descripcion=f"Creada opción de clasificación: {instance.valor} en set {instance.set_clas.nombre}",
-            usuario=self.request.user,
             detalles={
                 "opcion_id": instance.id,
                 "opcion_valor": instance.valor,
@@ -2096,8 +2043,6 @@ class ClasificacionOptionViewSet(viewsets.ModelViewSet):
                 "set_nombre": instance.set_clas.nombre,
                 "accion_origen": "manual_sets_tab",
             },
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
     def perform_update(self, serializer):
@@ -2105,13 +2050,12 @@ class ClasificacionOptionViewSet(viewsets.ModelViewSet):
         instance = serializer.save()
 
         # Registrar edición de opción
-        registrar_actividad_tarjeta(
+        self.log_update(
             cliente_id=instance.set_clas.cliente.id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="clasificacion",
             accion="option_edit",
             descripcion=f"Editada opción de clasificación: {old_instance.valor} → {instance.valor} en set {instance.set_clas.nombre}",
-            usuario=self.request.user,
             detalles={
                 "opcion_id": instance.id,
                 "valor_anterior": old_instance.valor,
@@ -2120,8 +2064,6 @@ class ClasificacionOptionViewSet(viewsets.ModelViewSet):
                 "set_nombre": instance.set_clas.nombre,
                 "accion_origen": "manual_sets_tab",
             },
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
     def perform_destroy(self, instance):
@@ -2137,39 +2079,34 @@ class ClasificacionOptionViewSet(viewsets.ModelViewSet):
             super().perform_destroy(instance)
 
             # Registrar eliminación de opción
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=opcion_info["cliente_id"],
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="clasificacion",
                 accion="option_delete",
                 descripcion=f'Eliminada opción de clasificación: {opcion_info["valor"]} del set {opcion_info["set_nombre"]}',
-                usuario=self.request.user,
                 detalles={**opcion_info, "accion_origen": "manual_sets_tab"},
-                resultado="exito",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
         except Exception as e:
             # Registrar error
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=opcion_info["cliente_id"],
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="clasificacion",
                 accion="option_delete",
                 descripcion=f'Error al eliminar opción de clasificación: {opcion_info["valor"]} - {str(e)}',
-                usuario=self.request.user,
                 detalles={
                     **opcion_info,
                     "error": str(e),
                     "accion_origen": "manual_sets_tab",
                 },
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
             raise
 
 
-class AccountClassificationViewSet(viewsets.ModelViewSet):
+class AccountClassificationViewSet(ActivityLogMixin, viewsets.ModelViewSet):
     queryset = AccountClassification.objects.select_related(
         "cuenta", "set_clas", "opcion", "asignado_por"
     ).all()
@@ -2191,21 +2128,18 @@ class AccountClassificationViewSet(viewsets.ModelViewSet):
         instance = serializer.save(asignado_por=self.request.user.usuario)
 
         # Registrar actividad
-        registrar_actividad_tarjeta(
+        self.log_create(
             cliente_id=instance.cuenta.cliente.id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="clasificacion",
             accion="individual_create",
             descripcion=f"Creada clasificación: {instance.cuenta.codigo} → {instance.set_clas.nombre}: {instance.opcion.valor}",
-            usuario=self.request.user,
             detalles={
                 "cuenta_id": instance.cuenta.id,
                 "cuenta_codigo": instance.cuenta.codigo,
                 "set_nombre": instance.set_clas.nombre,
                 "opcion_valor": instance.opcion.valor,
             },
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
     def perform_update(self, serializer):
@@ -2213,13 +2147,12 @@ class AccountClassificationViewSet(viewsets.ModelViewSet):
         instance = serializer.save()
 
         # Registrar actividad
-        registrar_actividad_tarjeta(
+        self.log_update(
             cliente_id=instance.cuenta.cliente.id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="clasificacion",
             accion="individual_edit",
             descripcion=f"Editada clasificación: {instance.cuenta.codigo} → {instance.set_clas.nombre}: {instance.opcion.valor}",
-            usuario=self.request.user,
             detalles={
                 "cuenta_id": instance.cuenta.id,
                 "cuenta_codigo": instance.cuenta.codigo,
@@ -2230,8 +2163,6 @@ class AccountClassificationViewSet(viewsets.ModelViewSet):
                     "opcion_nueva": instance.opcion.valor,
                 },
             },
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
     def perform_destroy(self, instance):
@@ -2247,16 +2178,13 @@ class AccountClassificationViewSet(viewsets.ModelViewSet):
         instance.delete()
 
         # Registrar actividad
-        registrar_actividad_tarjeta(
+        self.log_delete(
             cliente_id=cliente_id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="clasificacion",
             accion="individual_delete",
             descripcion=f'Eliminada clasificación: {clasificacion_info["cuenta_codigo"]} → {clasificacion_info["set_nombre"]}: {clasificacion_info["opcion_valor"]}',
-            usuario=self.request.user,
             detalles=clasificacion_info,
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
 
@@ -2281,7 +2209,7 @@ class AuxiliarViewSet(viewsets.ModelViewSet):
 # ViewSets para uploads con logging de cambios
 
 
-class ClasificacionCuentaArchivoViewSet(viewsets.ModelViewSet):
+class ClasificacionCuentaArchivoViewSet(ActivityLogMixin, viewsets.ModelViewSet):
     """
     ViewSet para manejar los registros raw de clasificaciones antes del mapeo
     """
@@ -2318,21 +2246,18 @@ class ClasificacionCuentaArchivoViewSet(viewsets.ModelViewSet):
                 )
 
                 # Registrar creación manual
-                registrar_actividad_tarjeta(
+                self.log_create(
                     cliente_id=upload_log.cliente.id,
                     periodo=date.today().strftime("%Y-%m"),
                     tarjeta="clasificacion",
                     accion="manual_create",
                     descripcion=f"Creado registro clasificación: {instance.numero_cuenta}",
-                    usuario=self.request.user,
                     detalles={
                         "numero_cuenta": instance.numero_cuenta,
                         "clasificaciones": instance.clasificaciones,
                         "upload_log_id": upload_log_id,
                         "id": instance.id,
                     },
-                    resultado="exito",
-                    ip_address=self.request.META.get("REMOTE_ADDR"),
                 )
 
             except UploadLog.DoesNotExist:
@@ -2341,20 +2266,17 @@ class ClasificacionCuentaArchivoViewSet(viewsets.ModelViewSet):
             instance = serializer.save()
             # Si no hay upload_log_id, registrar sin cliente específico
             if hasattr(instance, "cliente") and instance.cliente:
-                registrar_actividad_tarjeta(
+                self.log_create(
                     cliente_id=instance.cliente.id,
                     periodo=date.today().strftime("%Y-%m"),
                     tarjeta="clasificacion",
                     accion="manual_create",
                     descripcion=f"Creado registro clasificación: {instance.numero_cuenta}",
-                    usuario=self.request.user,
                     detalles={
                         "numero_cuenta": instance.numero_cuenta,
                         "clasificaciones": instance.clasificaciones,
                         "id": instance.id,
                     },
-                    resultado="exito",
-                    ip_address=self.request.META.get("REMOTE_ADDR"),
                 )
 
     def perform_update(self, serializer):
@@ -2373,13 +2295,12 @@ class ClasificacionCuentaArchivoViewSet(viewsets.ModelViewSet):
 
             # Registrar edición
             if cliente_id:
-                registrar_actividad_tarjeta(
+                self.log_update(
                     cliente_id=cliente_id,
                     periodo=date.today().strftime("%Y-%m"),
                     tarjeta="clasificacion",
                     accion="manual_edit",
                     descripcion=f"Editado registro clasificación ID:{instance.id}: {old_instance.numero_cuenta} → {instance.numero_cuenta}",
-                    usuario=self.request.user,
                     detalles={
                         "id": instance.id,
                         "cambios": {
@@ -2396,27 +2317,23 @@ class ClasificacionCuentaArchivoViewSet(viewsets.ModelViewSet):
                             instance.upload_log.id if instance.upload_log else None
                         ),
                     },
-                    resultado="exito",
-                    ip_address=self.request.META.get("REMOTE_ADDR"),
                 )
 
         except Exception as e:
             # Registrar error
             if cliente_id:
-                registrar_actividad_tarjeta(
+                self.log_update(
                     cliente_id=cliente_id,
                     periodo=date.today().strftime("%Y-%m"),
                     tarjeta="clasificacion",
                     accion="manual_edit",
                     descripcion=f"Error al editar registro clasificación ID:{old_instance.id}: {str(e)}",
-                    usuario=self.request.user,
                     detalles={
                         "error": str(e),
                         "id": old_instance.id,
                         "data": self.request.data,
                     },
                     resultado="error",
-                    ip_address=self.request.META.get("REMOTE_ADDR"),
                 )
             raise
 
@@ -2438,31 +2355,26 @@ class ClasificacionCuentaArchivoViewSet(viewsets.ModelViewSet):
 
             # Registrar eliminación
             if cliente_id:
-                registrar_actividad_tarjeta(
+                self.log_delete(
                     cliente_id=cliente_id,
                     periodo=date.today().strftime("%Y-%m"),
                     tarjeta="clasificacion",
                     accion="manual_delete",
                     descripcion=f'Eliminado registro clasificación: {registro_info["numero_cuenta"]}',
-                    usuario=self.request.user,
                     detalles=registro_info,
-                    resultado="exito",
-                    ip_address=self.request.META.get("REMOTE_ADDR"),
                 )
 
         except Exception as e:
             # Registrar error
             if cliente_id:
-                registrar_actividad_tarjeta(
+                self.log_delete(
                     cliente_id=cliente_id,
                     periodo=date.today().strftime("%Y-%m"),
                     tarjeta="clasificacion",
                     accion="manual_delete",
                     descripcion=f'Error al eliminar registro clasificación ID:{registro_info["id"]}: {str(e)}',
-                    usuario=self.request.user,
                     detalles={"error": str(e), **registro_info},
                     resultado="error",
-                    ip_address=self.request.META.get("REMOTE_ADDR"),
                 )
             raise
 
@@ -2552,7 +2464,7 @@ class ClasificacionCuentaArchivoViewSet(viewsets.ModelViewSet):
         )
 
 
-class NombresEnInglesUploadViewSet(viewsets.ModelViewSet):
+class NombresEnInglesUploadViewSet(ActivityLogMixin, viewsets.ModelViewSet):
     queryset = NombresEnInglesUpload.objects.all()
     serializer_class = NombresEnInglesUploadSerializer
     permission_classes = [IsAuthenticated]
@@ -2574,21 +2486,18 @@ class NombresEnInglesUploadViewSet(viewsets.ModelViewSet):
             logger.warning(f"Error al limpiar archivos temporales: {str(e)}")
 
         # Registrar actividad
-        registrar_actividad_tarjeta(
+        self.log_create(
             cliente_id=instance.cliente.id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="clasificacion",  # Nombres en inglés forma parte de clasificaciones
             accion="upload_excel",
             descripcion=f"Subido archivo de nombres en inglés: {instance.archivo.name}",
-            usuario=self.request.user,
             detalles={
                 "nombre_archivo": instance.archivo.name,
                 "tamaño_bytes": instance.archivo.size if instance.archivo else None,
                 "upload_id": instance.id,
                 "tipo_archivo": "nombres_ingles",
             },
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
         # Disparar tarea de procesamiento en background
@@ -2597,13 +2506,12 @@ class NombresEnInglesUploadViewSet(viewsets.ModelViewSet):
         except Exception as e:
             logger.error(f"Error al disparar tarea de procesamiento: {str(e)}")
             # Registrar error en el procesamiento
-            registrar_actividad_tarjeta(
+            self.log_create(
                 cliente_id=instance.cliente.id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="clasificacion",
                 accion="process_error",
                 descripcion=f"Error al iniciar procesamiento de {instance.archivo.name}: {str(e)}",
-                usuario=self.request.user,
                 detalles={
                     "error": str(e),
                     "nombre_archivo": instance.archivo.name,
@@ -2611,27 +2519,23 @@ class NombresEnInglesUploadViewSet(viewsets.ModelViewSet):
                     "tipo_archivo": "nombres_ingles",
                 },
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
     def perform_update(self, serializer):
         instance = serializer.save()
 
         # Registrar actividad
-        registrar_actividad_tarjeta(
+        self.log_update(
             cliente_id=instance.cliente.id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="clasificacion",
             accion="manual_edit",
             descripcion=f"Actualizado archivo de nombres en inglés: {instance.archivo.name}",
-            usuario=self.request.user,
             detalles={
                 "nombre_archivo": instance.archivo.name,
                 "upload_id": instance.id,
                 "tipo_archivo": "nombres_ingles",
             },
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
     def perform_destroy(self, instance):
@@ -2654,30 +2558,23 @@ class NombresEnInglesUploadViewSet(viewsets.ModelViewSet):
             instance.delete()
 
             # Registrar eliminación exitosa
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=cliente_id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="clasificacion",
-                accion="manual_delete",
                 descripcion=f'Eliminado archivo de nombres en inglés: {archivo_info["nombre_archivo"]}',
-                usuario=self.request.user,
                 detalles=archivo_info,
-                resultado="exito",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
         except Exception as e:
             # Registrar error en eliminación
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=cliente_id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="clasificacion",
-                accion="manual_delete",
                 descripcion=f"Error al eliminar archivo de nombres en inglés: {str(e)}",
-                usuario=self.request.user,
                 detalles={"error": str(e), **archivo_info},
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
             raise
 
@@ -2744,7 +2641,7 @@ class NombresEnInglesUploadViewSet(viewsets.ModelViewSet):
             return Response({"error": str(e)}, status=400)
 
 
-class LibroMayorUploadViewSet(viewsets.ModelViewSet):
+class LibroMayorUploadViewSet(ActivityLogMixin, viewsets.ModelViewSet):
     queryset = LibroMayorUpload.objects.all()
     serializer_class = LibroMayorUploadSerializer
     permission_classes = [IsAuthenticated]
@@ -2760,40 +2657,34 @@ class LibroMayorUploadViewSet(viewsets.ModelViewSet):
         instance = serializer.save()
 
         # Registrar actividad
-        registrar_actividad_tarjeta(
+        self.log_create(
             cliente_id=instance.cierre.cliente.id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="libro_mayor",
             accion="upload_excel",
             descripcion=f"Subido archivo de libro mayor: {instance.archivo.name}",
-            usuario=self.request.user,
             detalles={
                 "nombre_archivo": instance.archivo.name,
                 "cierre_id": instance.cierre.id,
                 "upload_id": instance.id,
             },
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
     def perform_update(self, serializer):
         instance = serializer.save()
 
         # Registrar actividad
-        registrar_actividad_tarjeta(
+        self.log_update(
             cliente_id=instance.cierre.cliente.id,
             periodo=date.today().strftime("%Y-%m"),
             tarjeta="libro_mayor",
             accion="manual_edit",
             descripcion=f"Actualizado archivo de libro mayor: {instance.archivo.name}",
-            usuario=self.request.user,
             detalles={
                 "nombre_archivo": instance.archivo.name,
                 "cierre_id": instance.cierre.id,
                 "upload_id": instance.id,
             },
-            resultado="exito",
-            ip_address=self.request.META.get("REMOTE_ADDR"),
         )
 
     def perform_destroy(self, instance):
@@ -2816,30 +2707,23 @@ class LibroMayorUploadViewSet(viewsets.ModelViewSet):
             instance.delete()
 
             # Registrar eliminación exitosa
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=cliente_id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="libro_mayor",
-                accion="manual_delete",
                 descripcion=f'Eliminado archivo de libro mayor: {archivo_info["nombre_archivo"]}',
-                usuario=self.request.user,
                 detalles=archivo_info,
-                resultado="exito",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
 
         except Exception as e:
             # Registrar error en eliminación
-            registrar_actividad_tarjeta(
+            self.log_delete(
                 cliente_id=cliente_id,
                 periodo=date.today().strftime("%Y-%m"),
                 tarjeta="libro_mayor",
-                accion="manual_delete",
                 descripcion=f"Error al eliminar archivo de libro mayor: {str(e)}",
-                usuario=self.request.user,
                 detalles={"error": str(e), **archivo_info},
                 resultado="error",
-                ip_address=self.request.META.get("REMOTE_ADDR"),
             )
             raise
 


### PR DESCRIPTION
## Summary
- implement `ActivityLogMixin` with common logging methods
- apply mixin to contabilidad viewsets
- refactor create/update/delete hooks to use the new mixin

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685a377975248323a76fc2245c90c947